### PR TITLE
Fix volume texture creation for Vulkan and D3D12

### DIFF
--- a/Framework/Source/API/D3D/D3D12/D3D12Texture.cpp
+++ b/Framework/Source/API/D3D/D3D12/D3D12Texture.cpp
@@ -106,7 +106,18 @@ namespace Falcor
         desc.Width = align_to(getFormatWidthCompressionRatio(mFormat), mWidth);
         desc.Height = align_to(getFormatHeightCompressionRatio(mFormat), mHeight);
         desc.Flags = getD3D12ResourceFlags(mBindFlags);
-        desc.DepthOrArraySize = (mType == Texture::Type::TextureCube) ? mArraySize * 6 : mArraySize;
+        if (mType == Texture::Type::TextureCube)
+        {
+            desc.DepthOrArraySize = mArraySize * 6;
+        }
+        else if (mType == Texture::Type::Texture3D)
+        {
+            desc.DepthOrArraySize = mDepth;
+        }
+        else
+        {
+            desc.DepthOrArraySize = mArraySize;
+        }
         desc.SampleDesc.Count = mSampleCount;
         desc.SampleDesc.Quality = 0;
         desc.Dimension = getResourceDimension(mType);

--- a/Framework/Source/API/Vulkan/VKCopyContext.cpp
+++ b/Framework/Source/API/Vulkan/VKCopyContext.cpp
@@ -54,7 +54,9 @@ namespace Falcor
         uint32_t perH = getFormatHeightCompressionRatio(format);
         uint32_t bh = align_to(perH, h) / perH;
 
-        uint32_t size = bh * bw * getFormatBytesPerBlock(format);
+        uint32_t d = pTexture->getDepth(mipLevel);
+
+        uint32_t size = bh * bw * d * getFormatBytesPerBlock(format);
         return size;
     }
 


### PR DESCRIPTION
I'm using Falcor for prototyping, it's awesome, thanks for you guys to make it available for public.

During development I found that there are two issues with volume texture creation. 
First one is texture data size calculation in Vulkan is incorrect so that volume texture is not fully initialized. I fixed it by take depth of texture into account.
Second one is parameters used to create texture is not setup properly in D3D12 implementation.

I test Vulkan and D3D12 separately, so that there are two commits to fix the issue, I can merge all those modifications into one commit if it's more convenient for you guys to maintain the codebase. 