### PR TITLE
[vulkan] Performance fix for buffer creation

### DIFF
--- a/Framework/Source/API/Vulkan/VKBuffer.cpp
+++ b/Framework/Source/API/Vulkan/VKBuffer.cpp
@@ -115,7 +115,7 @@ namespace Falcor
             }
             else
             {
-                mApiHandle = createBuffer(mSize, mBindFlags, Device::MemoryType::Upload);
+                mApiHandle = createBuffer(mSize, mBindFlags, Device::MemoryType::Default);
             }
         }
         return true;


### PR DESCRIPTION
In some cases, buffers were created on the "upload" heap that should have been created in the "default" heap, leading to reduced performance under Vulkan (as compared to D3D12).
This problem and fix was identified by Leroy Sikkes.

Informal testing: on the GPU I have installed at the moment (GeForce GTX 980), loading `dragon.bin` in the ModelViewer app used to result in ~170fps, and now yields > 450fps. Performance on more realistic scenes from ORCA (e.g., Bistro) has not seen similar gains.