### PR TITLE
Try to load shaders in background/worker threads.

### DIFF
--- a/Framework/Source/API/Shader.cpp
+++ b/Framework/Source/API/Shader.cpp
@@ -1,0 +1,58 @@
+/***************************************************************************
+# Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***************************************************************************/
+#include "Framework.h"
+#include "API/Shader.h"
+
+namespace Falcor
+{
+    Shader::SharedPtr Shader::create(const Blob& shaderBlob, ShaderType type, std::string const&  entryPointName, std::string& log)
+    {
+        SharedPtr pShader = SharedPtr(new Shader(type));
+
+        // We will put the actual expensive initialization work in a background thread,
+        // so that it can proceed asynchronously from other application work.
+
+        std::promise<void> loadingPromise;
+        pShader->mLoadingFuture = loadingPromise.get_future();
+
+        std::thread loadingThread([=](std::promise<void> p)
+        {
+            std::string localLog;
+            pShader->init(shaderBlob, entryPointName, localLog);
+            p.set_value();
+        }, std::move(loadingPromise));
+        loadingThread.detach();
+
+        return pShader;
+    }
+
+    void Shader::waitForLoad() const
+    {
+        mLoadingFuture.wait();
+    }
+}

--- a/Framework/Source/API/Shader.h
+++ b/Framework/Source/API/Shader.h
@@ -26,6 +26,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***************************************************************************/
 #pragma once
+
+#include <future>
 #include <string>
 #include <unordered_set>
 
@@ -67,17 +69,13 @@ namespace Falcor
             \param[out] log This string will contain the error log message in case shader compilation failed
             \return If success, a new shader object, otherwise nullptr
         */
-        static SharedPtr create(const Blob& shaderBlob, ShaderType type, std::string const&  entryPointName, std::string& log)
-        {
-            SharedPtr pShader = SharedPtr(new Shader(type));
-            return pShader->init(shaderBlob, entryPointName, log) ? pShader : nullptr;
-        }
+        static SharedPtr create(const Blob& shaderBlob, ShaderType type, std::string const&  entryPointName, std::string& log);
 
         virtual ~Shader();
 
         /** Get the API handle.
         */
-        ApiHandle getApiHandle() const { return mApiHandle; }
+        ApiHandle getApiHandle() const { waitForLoad(); return mApiHandle; }
 
         /** Get the shader Type
         */
@@ -97,6 +95,10 @@ namespace Falcor
         ShaderType mType;
         ApiHandle mApiHandle;
         void* mpPrivateData = nullptr;
+
+        // Future to represent compilation status in background/worker thread
+        std::future<void>   mLoadingFuture;
+        void waitForLoad() const;
     };
 
 }

--- a/Framework/Source/Falcor.vcxproj
+++ b/Framework/Source/Falcor.vcxproj
@@ -300,6 +300,7 @@
     <ClCompile Include="API\Resource.cpp" />
     <ClCompile Include="API\ResourceViews.cpp" />
     <ClCompile Include="API\Sampler.cpp" />
+    <ClCompile Include="API\Shader.cpp" />
     <ClCompile Include="API\StructuredBuffer.cpp" />
     <ClCompile Include="API\Texture.cpp" />
     <ClCompile Include="API\ConstantBuffer.cpp" />

--- a/Framework/Source/Falcor.vcxproj.filters
+++ b/Framework/Source/Falcor.vcxproj.filters
@@ -531,6 +531,9 @@
     <ClCompile Include="Effects\TAA\TAA.cpp">
       <Filter>Effects\TAA</Filter>
     </ClCompile>
+    <ClCompile Include="API\Shader.cpp">
+      <Filter>API</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Graphics\Model\Animation.h">


### PR DESCRIPTION
I'm using the FeatureDemo D3D12 with the Bistro interior to test things here, and in my own testing it spends about 75% or more of the startup time just in calls to `Shader::init` (which is where we call `D3DCompile`).

The basic idea of the changes here is to try to load shaders in background threads, but to do so transparently, so that the client of the API need not change their actions. Basically, instead of `Shader::create` immediately calling `Shader::init`, it now returns a `Shader` object right away, and then calls `Shader::init` on another thread. When the user asks for something that requires the result of `init` (currently just the API handle), the implementation will wait for that background work to complete (currently I use `std::future` for this).

Importantly, the implementation of `ProgramVersion` doesn't try to request the API handles, so that we can create a program version from a few shaders and return that further up the call chain, all while the actual shader compile is going on.
In principle, an application should be able to call `Program::getActiveVersion()` to kick off the async compilation, and then only block on completion when they go to actually *use* that program version (e.g., as part of a PSO).

The place where this breaks down right now is that most code actually ends up using a program version almost as soon as it is created, so there isn't much opportunity to buffer up background work.
A nice companion fix would be to have the scene renderer support doing a "pre-pass" over the scene to find the program versions it will use, without actually rendering anything. Such a pass would kick off all the compilation required, while avoiding block on the results.

More notes:

- This change doesn't try to do anything clever with respect to the Slang part of compilation. The actual Slang compilation steps don't take very long as the moment, and they are required to get reflection data (which is used immediately), so trying to parallelize that work would require a lot of Falcor changes.

- One gotcha from the above is that the potential speedup here only applies to D3D12 right now, because for Vulkan we let Slang invoke the downstream compiler for us. The right fix there is probably for Slang to do a similar async approach for its downstream compiler invocations.

- The main reason this change isn't ready for prime-time is that it isn't really clear what we should do with any compilation failures that occur. By pushing the HLSL-to-bytecode compilation into a background thread, we create a situation where we don't know that a compile has failed until late in the process, and the current "abort/retry?" dialog box behavior may be hard to implement in that context (since we may not have the context to meaningfully restart/retry things).

- Another code smell here is that I'm just creating a raw `std::thread` for every shader compile. For now the overhead of this doesn't seem too bad (since the compilation itself is way more expensive), but it would be good to have a real thread pool in place (I'm not convinced the current `Falcor::ThreadPool` does what its name implies...).

Further input is welcome. I'd like to get this into shape to commit soon, since shader compilation is a major factor in startup and iteration times.