### PR TITLE
Flush upload heap after every material's textures have loaded

### DIFF
--- a/Framework/Source/API/Device.cpp
+++ b/Framework/Source/API/Device.cpp
@@ -203,6 +203,12 @@ namespace Falcor
         mFrameID++;
     }
 
+    void Device::flushAndSync()
+    {
+        mpRenderContext->flush(true);
+        executeDeferredReleases();
+    }
+
     Fbo::SharedPtr Device::resizeSwapChain(uint32_t width, uint32_t height)
     {
         mpRenderContext->flush(true);

--- a/Framework/Source/API/Device.h
+++ b/Framework/Source/API/Device.h
@@ -127,6 +127,10 @@ namespace Falcor
         */
         void present();
 
+        /** Flushes pipeline, releases resources, and blocks until completion
+        */
+        void flushAndSync();
+
         /** Check if vertical sync is enabled
         */
         bool isVsyncEnabled() const { return mVsyncOn; }

--- a/Framework/Source/Graphics/Model/Loaders/AssimpModelImporter.cpp
+++ b/Framework/Source/Graphics/Model/Loaders/AssimpModelImporter.cpp
@@ -44,6 +44,7 @@
 #include "API/VertexLayout.h"
 #include "Data/VertexAttrib.h"
 #include "Utils/StringUtils.h"
+#include "API/Device.h"
 
 namespace Falcor
 {
@@ -315,6 +316,9 @@ namespace Falcor
                 }
             }
         }
+
+        // Flush upload heap after every material so we don't accumulate a ton of memory usage when loading a model with a lot of textures
+        gpDevice->flushAndSync();
     }
 
     Material::SharedPtr AssimpModelImporter::createMaterial(const aiMaterial* pAiMaterial, const std::string& folder, bool isObjFile, bool useSrgb)

--- a/Framework/Source/Graphics/Model/Loaders/BinaryModelImporter.cpp
+++ b/Framework/Source/Graphics/Model/Loaders/BinaryModelImporter.cpp
@@ -40,6 +40,7 @@
 #include "API/Texture.h"
 #include "Graphics/Material/Material.h"
 #include "glm/geometric.hpp"
+#include "API/Device.h"
 
 namespace Falcor
 {
@@ -470,16 +471,20 @@ namespace Falcor
     {
         textures.assign(textureCount, TextureData());
 
+        bool success = true;
         for(uint32_t i = 0; i < textureCount; i++)
         {
             textures[i].name = readString(stream);
             if(loadBinaryTextureData(stream, modelName, textures[i]) == false)
             {
-                return false;
+                success = false;
+                break;
             }
         }
 
-        return true;
+        // Flush upload heap after every material so we don't accumulate a ton of memory usage when loading a model with a lot of textures
+        gpDevice->flushAndSync();
+        return success;
     }
 
     BinaryModelImporter::BinaryModelImporter(const std::string& fullpath) : mModelName(fullpath), mStream(fullpath.c_str(), BinaryFileStream::Mode::Read)


### PR DESCRIPTION
Implemented as discussed. Negligible effect on load time (something like a few ms per flush).