### PR TITLE
Update to Slang 0.8.3

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -8,7 +8,7 @@
         <dependency name="freeimage" version="3.17.0" linkPath="Framework/Externals/FreeImage"/>
         <dependency name="vulkansdk" version="1.0.51.0" linkPath="Framework/Externals/VulkanSDK"/>
         <dependency name="rapidjson" version="0.1" linkPath="Framework/Externals/RapidJson"/>
-        <dependency name="slang" version="0.7.8" linkPath="Framework/Externals/Slang"/>
+        <dependency name="slang" version="0.8.3" linkPath="Framework/Externals/Slang"/>
         <dependency name="falcor_media" version="1.0" linkPath="Media"/>
     </platform>
 </project>


### PR DESCRIPTION
This pulls in some bug fixes related to declarations of resources in `cbuffer`s.

I've confirmed that FeatureDemo works with the new version, but this change needs to be put through te full CI test suite before it gets merged.