### PR TITLE
Removed Configuration Name Restriction

### DIFF
--- a/Framework/BuildScripts/postbuild.bat
+++ b/Framework/BuildScripts/postbuild.bat
@@ -45,5 +45,5 @@ if /I "%6"=="ReleaseVK" set outdirtype=Release
 
 
 rem Call the Build Scripts to move the data.
-call %1BuildScripts\movedata.bat %1 %2 %3 %4 %5 %6 %7 %outdirtype%
+call %1BuildScripts\movedata.bat %1 %2 %3 %4 %5 %6 %7 %6
 

--- a/Framework/Source/Falcor.props
+++ b/Framework/Source/Falcor.props
@@ -21,7 +21,8 @@
       <AdditionalDependencies>slang.lib;Comctl32.lib;Shlwapi.lib;assimp.lib;freeimage.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;avcodec.lib;avutil.lib;avformat.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>"$(OutDir)\moveprojectdata.bat" "$(ProjectDir)" "$(OutDir)"</Command>
+      <Command>call $(FALCOR_CORE_DIRECTORY)\BuildScripts\postbuild.bat $(FALCOR_CORE_DIRECTORY)\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
+call $(OutDir)\moveprojectdata.bat $(ProjectDir) $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Framework/Source/Falcor.vcxproj
+++ b/Framework/Source/Falcor.vcxproj
@@ -1405,11 +1405,6 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      call $(ProjectDir)\..\BuildScripts\postbuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
-      </Command>
-    </PostBuildEvent>
     <PreBuildEvent>
       <Command>
       call $(ProjectDir)\..\BuildScripts\prebuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
@@ -1440,11 +1435,6 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      call $(ProjectDir)\..\BuildScripts\postbuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
-      </Command>
-    </PostBuildEvent>
     <PreBuildEvent>
       <Command>
       call $(ProjectDir)\..\BuildScripts\prebuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
@@ -1479,11 +1469,6 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      call $(ProjectDir)\..\BuildScripts\postbuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
-      </Command>
-    </PostBuildEvent>
     <PreBuildEvent>
       <Command>
       call $(ProjectDir)\..\BuildScripts\prebuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
@@ -1523,11 +1508,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      call $(ProjectDir)\..\BuildScripts\postbuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
-      </Command>
-    </PostBuildEvent>
     <PreBuildEvent>
       <Command>
       call $(ProjectDir)\..\BuildScripts\prebuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
@@ -1561,11 +1541,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      call $(ProjectDir)\..\BuildScripts\postbuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
-      </Command>
-    </PostBuildEvent>
     <PreBuildEvent>
       <Command>
       call $(ProjectDir)\..\BuildScripts\prebuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
@@ -1604,11 +1579,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      call $(ProjectDir)\..\BuildScripts\postbuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)
-      </Command>
-    </PostBuildEvent>
     <PreBuildEvent>
       <Command>
       call $(ProjectDir)\..\BuildScripts\prebuild.bat $(ProjectDir)\..\ $(SolutionDir) $(ProjectDir) $(PlatformName) $(PlatformShortName) $(Configuration) $(OutDir)


### PR DESCRIPTION
Hello,  

"PostBuildEvent"s in the "Falcor.vcxproj" is restricting configuration name in a project that uses Falcor by reference to "Debug" or "Release". It is possible that a user might have custom names as neither "Debug" nor "Release". Fork fixes the problem by modifying the "postbuild.bat" slightly and moving "PostBuildEvent" logic from "Falcor.vcxproj" to "Falcor.prop".

Thanks.