### PR TITLE
Feature Demo fixes for Skybox/EnvMap loading

### DIFF
--- a/Samples/FeatureDemo/FeatureDemo.cpp
+++ b/Samples/FeatureDemo/FeatureDemo.cpp
@@ -49,8 +49,8 @@ static const float kDX11SamplePattern[8][2] = { { 1.0f / 16.0f, -3.0f / 16.0f },
 
 void FeatureDemo::initDepthPass()
 {
-	mDepthPass.pProgram = GraphicsProgram::createFromFile("DepthPass.vs.slang", "DepthPass.ps.slang");
-	mDepthPass.pVars = GraphicsVars::create(mDepthPass.pProgram->getActiveVersion()->getReflector());
+    mDepthPass.pProgram = GraphicsProgram::createFromFile("DepthPass.vs.slang", "DepthPass.ps.slang");
+    mDepthPass.pVars = GraphicsVars::create(mDepthPass.pProgram->getActiveVersion()->getReflector());
 }
 
 void FeatureDemo::initLightingPass()
@@ -59,10 +59,10 @@ void FeatureDemo::initLightingPass()
     mLightingPass.pProgram->addDefine("_LIGHT_COUNT", std::to_string(mpSceneRenderer->getScene()->getLightCount()));
     initControls();
     mLightingPass.pVars = GraphicsVars::create(mLightingPass.pProgram->getActiveVersion()->getReflector());
-	
+    
     DepthStencilState::Desc dsDesc;
-	dsDesc.setDepthTest(true).setStencilTest(false).setDepthWriteMask(false).setDepthFunc(DepthStencilState::Func::LessEqual);
-	mLightingPass.pDsState = DepthStencilState::create(dsDesc);
+    dsDesc.setDepthTest(true).setStencilTest(false).setDepthWriteMask(false).setDepthFunc(DepthStencilState::Func::LessEqual);
+    mLightingPass.pDsState = DepthStencilState::create(dsDesc);
 
     RasterizerState::Desc rsDesc;
     rsDesc.setCullMode(RasterizerState::CullMode::None);
@@ -104,11 +104,26 @@ void FeatureDemo::setSceneSampler(uint32_t maxAniso)
 void FeatureDemo::applyCustomSceneVars(const Scene* pScene, const std::string& filename)
 {
     std::string folder = getDirectoryFromFile(filename);
+
     Scene::UserVariable var = pScene->getUserVariable("sky_box");
-    if (var.type == Scene::UserVariable::Type::String) initSkyBox(folder + '\\' + var.str);
+    if (var.type == Scene::UserVariable::Type::String)
+    {
+        initSkyBox(folder + '\\' + var.str);
+    }
+    else
+    {
+        mSkyBox.pEffect = nullptr;
+    }
 
     var = pScene->getUserVariable("env_map");
-    if (var.type == Scene::UserVariable::Type::String) initEnvMap(folder + '\\' + var.str);
+    if (var.type == Scene::UserVariable::Type::String) 
+    {
+        initEnvMap(folder + '\\' + var.str);
+    }
+    else
+    {
+        mpEnvMap = nullptr;
+    }
 
     var = pScene->getUserVariable("env_map_intensity_scale");
     if (var.type == Scene::UserVariable::Type::Double) mEnvMapFactorScale = (float)var.d64;
@@ -176,6 +191,8 @@ void FeatureDemo::loadModel(const std::string& filename, bool showProgressBar)
     pScene->addModelInstance(pModel, "instance");
 
     initScene(pScene);
+    initSkyBox("LightProbes\\10-Shiodome_Stairs_3k.dds");
+    initEnvMap("LightProbes\\10-Shiodome_Stairs_3k.dds");
 }
 
 void FeatureDemo::loadScene(const std::string& filename, bool showProgressBar)
@@ -232,8 +249,6 @@ void FeatureDemo::onLoad()
 {
     mpState = GraphicsState::create();
 
-    initSkyBox("LightProbes\\10-Shiodome_Stairs_3k.dds");
-    initEnvMap("LightProbes\\10-Shiodome_Stairs_3k.dds");
     initPostProcess();
     initializeTesting();
 }
@@ -279,15 +294,15 @@ void FeatureDemo::postProcess()
 
 void FeatureDemo::depthPass()
 {
-	PROFILE(depthPass);
-	if (mEnableDepthPass == false) 
-	{
-		return;
-	}
+    PROFILE(depthPass);
+    if (mEnableDepthPass == false) 
+    {
+        return;
+    }
 
     mpState->setFbo(mpDepthPassFbo);
-	mpState->setProgram(mDepthPass.pProgram);
-	mpRenderContext->setGraphicsVars(mDepthPass.pVars);
+    mpState->setProgram(mDepthPass.pProgram);
+    mpRenderContext->setGraphicsVars(mDepthPass.pVars);
     
     auto renderMode = mControls[EnableTransparency].enabled ? FeatureDemoSceneRenderer::Mode::Opaque : FeatureDemoSceneRenderer::Mode::All;
     mpSceneRenderer->setRenderMode(renderMode);
@@ -298,7 +313,7 @@ void FeatureDemo::lightingPass()
 {
     PROFILE(lightingPass);
     mpState->setProgram(mLightingPass.pProgram);
-	mpState->setDepthStencilState(mEnableDepthPass ? mLightingPass.pDsState : nullptr);
+    mpState->setDepthStencilState(mEnableDepthPass ? mLightingPass.pDsState : nullptr);
     mpRenderContext->setGraphicsVars(mLightingPass.pVars);
     ConstantBuffer::SharedPtr pCB = mLightingPass.pVars->getConstantBuffer("PerFrameCB");
     pCB["gEnvMapFactorScale"] = mEnvMapFactorScale;
@@ -332,8 +347,8 @@ void FeatureDemo::lightingPass()
         mpSceneRenderer->setRenderMode(FeatureDemoSceneRenderer::Mode::All);
         mpSceneRenderer->renderScene(mpRenderContext.get());
     }
-	mpRenderContext->flush();
-	mpState->setDepthStencilState(nullptr);
+    mpRenderContext->flush();
+    mpState->setDepthStencilState(nullptr);
 }
 
 void FeatureDemo::renderOpaqueObjects()
@@ -366,7 +381,7 @@ void FeatureDemo::shadowPass()
     {
         mShadowPass.camVpAtLastCsmUpdate = mpSceneRenderer->getScene()->getActiveCamera()->getViewProjMatrix();
         mShadowPass.pCsm->setup(mpRenderContext.get(), mpSceneRenderer->getScene()->getActiveCamera().get(), mEnableDepthPass ? mpDepthPassFbo->getDepthStencilTexture() : nullptr);
-		mpRenderContext->flush();
+        mpRenderContext->flush();
     }
 }
 
@@ -439,7 +454,7 @@ void FeatureDemo::onBeginTestFrame()
 void FeatureDemo::onFrameRender()
 {
     beginTestFrame();
-	
+    
     if (mpSceneRenderer)
     {
         beginFrame();
@@ -449,9 +464,9 @@ void FeatureDemo::onFrameRender()
             mpSceneRenderer->update(mCurrentTime);
         }
 
-		depthPass();
+        depthPass();
         shadowPass();
-		mpState->setFbo(mpMainFbo);
+        mpState->setFbo(mpMainFbo);
         renderSkyBox();
         lightingPass();
         antiAliasing();

--- a/Samples/FeatureDemo/FeatureDemo.h
+++ b/Samples/FeatureDemo/FeatureDemo.h
@@ -44,7 +44,7 @@ public:
 
 private:
     Fbo::SharedPtr mpMainFbo;
-	Fbo::SharedPtr mpDepthPassFbo;
+    Fbo::SharedPtr mpDepthPassFbo;
     Fbo::SharedPtr mpResolveFbo;
     Fbo::SharedPtr mpPostProcessFbo;
 
@@ -69,16 +69,16 @@ private:
     {
         GraphicsVars::SharedPtr pVars;
         GraphicsProgram::SharedPtr pProgram;
-		DepthStencilState::SharedPtr pDsState;
+        DepthStencilState::SharedPtr pDsState;
         RasterizerState::SharedPtr pNoCullRS;
         BlendState::SharedPtr pAlphaBlendBS;
-	} mLightingPass;
+    } mLightingPass;
 
-	struct
-	{
-		GraphicsVars::SharedPtr pVars;
-		GraphicsProgram::SharedPtr pProgram;
-	} mDepthPass;
+    struct
+    {
+        GraphicsVars::SharedPtr pVars;
+        GraphicsProgram::SharedPtr pProgram;
+    } mDepthPass;
 
 
     //  The Temporal Anti-Aliasing Pass.
@@ -121,7 +121,7 @@ private:
 
     void beginFrame();
     void endFrame();
-	void depthPass();
+    void depthPass();
     void shadowPass();
     void renderSkyBox();
     void lightingPass();
@@ -139,7 +139,7 @@ private:
     void initSkyBox(const std::string& name);
     void initPostProcess();
     void initLightingPass();
-	void initDepthPass();
+    void initDepthPass();
     void initShadowPass();
     void initSSAO();
     void initEnvMap(const std::string& name);
@@ -206,7 +206,7 @@ private:
     bool mUseCameraPath = true;
     void applyCameraPathState();
     bool mPerMaterialShader = true;
-	bool mEnableDepthPass = true;
+    bool mEnableDepthPass = true;
 
     // Testing 
     void onInitializeTesting() override;


### PR DESCRIPTION
- Reset skybox and environment map if none are loaded by the scene. 
- Only load default skybox/envmap if loading a model file.
- Untabbed the files.