### PR TITLE
Fix Vulkan vertex attribute locations when using cross-compiled shaders

### DIFF
--- a/Framework/Source/API/ProgramReflection.h
+++ b/Framework/Source/API/ProgramReflection.h
@@ -363,6 +363,12 @@ namespace Falcor
         */
         const Variable* getVertexAttribute(const std::string& name) const;
 
+        /** Get the descriptor for a vertex-attribute with the given semantic
+            \param[in] semantic The semantic name used in the program
+            \return The variable desc of the attribute if it is found, otherwise nullptr
+        */
+        const Variable* getVertexAttributeBySemantic(const std::string& semantic) const;
+
         /** Get the descriptor for a fragment shader output
             \param[in] name The output variable name in the program
             \return The variable desc of the output if it is found, otherwise nullptr
@@ -413,6 +419,7 @@ namespace Falcor
         BufferData mBuffers[BufferReflection::kTypeCount];
         VariableMap mFragOut;
         VariableMap mVertAttr;
+        VariableMap mVertAttrBySemantic;
         ResourceMap mResources;
         uvec3 mThreadGroupSize;
         bool mIsSampleFrequency = false;

--- a/Framework/Source/API/Vulkan/VKGraphicsStateObject.cpp
+++ b/Framework/Source/API/Vulkan/VKGraphicsStateObject.cpp
@@ -43,7 +43,7 @@ namespace Falcor
 
         // Vertex Input State
         VertexInputStateCreateInfo vertexInputInfo;
-        initVkVertexLayoutInfo(mDesc.getVertexLayout().get(), vertexInputInfo);
+        initVkVertexLayoutInfo(mDesc.getVertexLayout().get(), vertexInputInfo, mDesc.getProgramVersion()->getReflector().get());
 
         // Input Assembly State
         VkPipelineInputAssemblyStateCreateInfo inputAssemblyInfo;

--- a/Framework/Source/API/Vulkan/VKState.cpp
+++ b/Framework/Source/API/Vulkan/VKState.cpp
@@ -321,7 +321,7 @@ namespace Falcor
         }
     }
 
-    void initVkVertexLayoutInfo(const VertexLayout* pLayout, VertexInputStateCreateInfo& infoOut)
+    void initVkVertexLayoutInfo(const VertexLayout* pLayout, VertexInputStateCreateInfo& infoOut, ProgramReflection const* pReflector)
     {
         // Build Vertex input and binding info
         infoOut.bindingDescs.clear();
@@ -342,9 +342,23 @@ namespace Falcor
 
                 for (uint32_t elemID = 0; elemID < pVB->getElementCount(); elemID++)
                 {
+                    // The vertex layout element will include a specified
+                    // shader location, but we may decide to override this
+                    // if the reflection data includes HLSL semantic
+                    // information that tells us the "right" location
+                    // for the given element.
+                    uint32_t shaderLocation = pVB->getElementShaderLocation(elemID);
+
+                    auto pAttribReflector = pReflector->getVertexAttributeBySemantic(
+                        pVB->getElementName(elemID));
+                    if (pAttribReflector)
+                    {
+                        shaderLocation = (uint32_t) pAttribReflector->location;
+                    }
+
                     // Per shader location specified
                     VkVertexInputAttributeDescription attribDesc = {};
-                    attribDesc.location = pVB->getElementShaderLocation(elemID);
+                    attribDesc.location = shaderLocation;
                     attribDesc.binding = (uint32_t)vb;
                     attribDesc.format = getVkFormat(pVB->getElementFormat(elemID));
                     attribDesc.offset = pVB->getElementOffset(elemID);

--- a/Framework/Source/API/Vulkan/VKState.h
+++ b/Framework/Source/API/Vulkan/VKState.h
@@ -56,7 +56,7 @@ namespace Falcor
     void initVkBlendInfo(const BlendState* pState, ColorBlendStateCreateInfo& infoOut);
     void initVkRasterizerInfo(const RasterizerState* pState, VkPipelineRasterizationStateCreateInfo& infoOut);
     void initVkDepthStencilInfo(const DepthStencilState* pState, VkPipelineDepthStencilStateCreateInfo& infoOut);
-    void initVkVertexLayoutInfo(const VertexLayout* pLayout, VertexInputStateCreateInfo& infoOut);
+    void initVkVertexLayoutInfo(const VertexLayout* pLayout, VertexInputStateCreateInfo& infoOut, ProgramReflection const* pReflector);
     void initVkSamplerInfo(const Sampler* pSampler, VkSamplerCreateInfo& infoOut);
     void initVkMultiSampleInfo(const BlendState* pState, const Fbo::Desc& fboDesc, const uint32_t& sampleMask, VkPipelineMultisampleStateCreateInfo& infoOut, bool enableSampleFrequency);
     void initVkInputAssemblyInfo(const Vao* pVao, VkPipelineInputAssemblyStateCreateInfo& infoOut);

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -8,7 +8,7 @@
         <dependency name="freeimage" version="3.17.0" linkPath="Framework/Externals/FreeImage"/>
         <dependency name="vulkansdk" version="1.0.51.0" linkPath="Framework/Externals/VulkanSDK"/>
         <dependency name="rapidjson" version="0.1" linkPath="Framework/Externals/RapidJson"/>
-        <dependency name="slang" version="0.7.8" linkPath="Framework/Externals/Slang"/>
+        <dependency name="slang" version="0.8.8" linkPath="Framework/Externals/Slang"/>
         <dependency name="glfw" version="3.2.1" linkPath="Framework/Externals/GLFW"/>
         <dependency name="falcor_media" version="1.0" linkPath="Media"/>
     </platform>


### PR DESCRIPTION
Fixes #23

The Vulkan back end has so far assumed that each vertex attribute "semantic" has a fixed location when used in GLSL coded, e.g.:

```c++
#define VERTEX_DIFFUSE_COLOR_LOC 7
```

The intention is that users can write code like the following in GLSL:

```glsl
layout(location= VERTEX_DIFFUSE_COLOR_LOC)
in vec4 diffuseColor;
```

In those cases, Slang will correctly pass through the declaration (and surface it in reflection data), and the Falcor code will populate a `VertexLayout` with that location, and all is well.

However, when an HLSL or Slang vertex shader is used, the user is instead relying on "semantics":

```hlsl
struct MyVertexInput {
    float3 p : POSITION;
    float4 c : DIFFUSE_COLOR;
};
```

In this case the cross-compiled GLSL will only have two vertex inputs, and they will be auto-assigned indices 0 and 1. Thus any code that constructs a `VertexLayout` expecting color at location 7 will lead to problems.

The fix that this change implements is to query the reflection information during PSO construction. For each vertex attribute in the vertex layout, we check to see if the reflection information contains a parameter with the same semantic. If it does, then we use the location from the reflection information, and ignore the location specified in the `VertexLayout` - this leads to the correct behavior when using HLSL shaders. If there is no matching-semantic input, then we rely on the fixed location already specified - this leads to the correct behavior when using GLSL shaders.