### PR TITLE
Fix invalid shader code generation when using empty material

### DIFF
--- a/Framework/Source/Graphics/Material/Material.h
+++ b/Framework/Source/Graphics/Material/Material.h
@@ -332,7 +332,7 @@ namespace Falcor
             uint64_t id;
             uint32_t refCount;
         };
-        mutable bool mDescDirty = false;
+        mutable bool mDescDirty = true;
         mutable std::string mDescString;
         mutable size_t mDescIdentifier;
         void updateDescIdentifier() const;


### PR DESCRIPTION
When a material is initially created is has an empty `mDescString`, but then also sets `mDescDirty = false`.
This means that if we ever try to render with a material before editing its structure (in a way that sets the dirty flag), then an empty string will be used for `_MS_STATIC_MATERIAL_DESC` and yield a syntax error in `Shading.slang` (which Slang dutifuly and accurately reports).

The fix is simple enough: initialize `mDescDirty = true` instead.