### PR TITLE
Vulkan+Slang parameter block fixes

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -30,8 +30,8 @@
         <package name="rapidjson" version="0.1" />
     </dependency>
     <dependency name="slang" linkPath="Framework/Externals/Slang">
-        <package name="slang" version="0.9.0" remotes="github-slang" />
-        <package name="slang" version="0.9.0" remotes="github-slang-linux" platforms="linux" />
+        <package name="slang" version="0.9.1" remotes="github-slang" />
+        <package name="slang" version="0.9.1" remotes="github-slang-linux" platforms="linux" />
     </dependency>
     <dependency name="glfw" linkPath="Framework/Externals/GLFW">
         <package name="glfw" version="3.2.1" platforms="win" />


### PR DESCRIPTION
The majority of the interesting fixes are in Slang, and come in Slang 0.9.1. This change just updates the Slang version that Falcor uses, and then also applies a small fix to the logic for computing the register space for a variable during reflection (a fix that I've been saying we'd need to make sooner or later).

Note: this doesn't yet fix Vulkan rendering with parameter blocks, but I'm putting this up as a PR so that it is easy for folks to grab.