### PR TITLE
Sync vsync state between UI display and swapchain.

### DIFF
--- a/Framework/Source/Sample.cpp
+++ b/Framework/Source/Sample.cpp
@@ -172,6 +172,7 @@ namespace Falcor
         mTimeScale = config.timeScale;
         mFixedTimeDelta = config.fixedTimeDelta;
         mFreezeTime = config.freezeTimeOnStartup;
+        mVsyncOn = config.deviceDesc.enableVsync;
 
         // Start the logger
         Logger::init();


### PR DESCRIPTION
When VSync is turn on in startup configuration, GUI is not show "VSYNC ON" 