### PR TITLE
Fix for issue #35 [Package '7za' at version '16.02' is missing from l…

### DIFF
--- a/packman/config.packman.xml
+++ b/packman/config.packman.xml
@@ -3,4 +3,5 @@
 			<credentials id="AKIAJHPSPBMWMTZS6TJA" key="vK3d0lHiQjEW9krFfvKA4OLpuHGxi2L4/Q4r4IuT"
 				errorUrl="https://gtl-gitlab.nvidia.com/halldor/packman/wikis/credentials/failure-using-s3-packman-read-access"/>
 	</remote>
+	<remote name="cloudfront" type="https" packageLocation="d2bmww5yym6ce8.cloudfront.net/${name}@${version}" />
 </config>

--- a/packman/packman
+++ b/packman/packman
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PM_PACKMAN_VERSION=5.0.1
+PM_PACKMAN_VERSION=5.1
 
 # Specify where packman command exists
 export PM_INSTALL_PATH=$(dirname ${BASH_SOURCE})
@@ -68,7 +68,7 @@ fi
 PM_7za_VERSION=16.02
 export PM_7za_PATH="$PM_PACKAGES_ROOT/chk/7za/$PM_7za_VERSION"
 if [ ! -f "$PM_7za_PATH" ]; then
-    $PM_PYTHON "$PM_MODULE" install 7za $PM_7za_VERSION -r packman:s3
+    $PM_PYTHON "$PM_MODULE" install 7za $PM_7za_VERSION -r packman:cloudfront
     if [ "$?" -ne 0 ]; then
         echo "Failure while installing required 7za package"
         exit 1
@@ -78,7 +78,7 @@ fi
 # Generate temporary file name for environment variables:
 PM_VAR_PATH=`mktemp -u -t tmp.XXXXX.$$.pmvars`
 
-$PM_PYTHON "$PM_MODULE" $* --var-path="$PM_VAR_PATH"
+$PM_PYTHON -u "$PM_MODULE" $* --var-path="$PM_VAR_PATH"
 exit_code=$?
 # Export the variables if the file was used and remove the file:
 if [ -f "$PM_VAR_PATH" ]; then

--- a/packman/packman.cmd
+++ b/packman/packman.cmd
@@ -8,11 +8,10 @@
 @if not defined PM_MODULE goto :MODULE_ENV_ERROR
 
 :: Generate temporary path for variable file
-:TEMP_VAR_PATH_LOOP
-@set "PM_VAR_PATH=%tmp%\tmp.%RANDOM%.pmvars"
-@if exist "%PM_VAR_PATH%" goto :TEMP_VAR_PATH_LOOP
+@for /f "delims=" %%a in ('powershell -ExecutionPolicy ByPass -NoLogo -NoProfile ^
+-File "%~dp0win-bootstrap\generate_temp_file_name.ps1"') do @set PM_VAR_PATH=%%a
 
-@"%PM_PYTHON%" "%PM_MODULE%" %* --var-path="%PM_VAR_PATH%"
+@"%PM_PYTHON%" -u "%PM_MODULE%" %* --var-path="%PM_VAR_PATH%"
 @if errorlevel 1 goto :eof
 
 :: Marshall environment variables into the current environment if they have been generated and remove temporary file

--- a/packman/win-bootstrap/configure.bat
+++ b/packman/win-bootstrap/configure.bat
@@ -1,4 +1,4 @@
-@set PM_PACKMAN_VERSION=5.0.1
+@set PM_PACKMAN_VERSION=5.1
 
 :: Specify where packman command is rooted
 @set PM_INSTALL_PATH=%~dp0..
@@ -91,7 +91,7 @@
 @set PM_7Za_PATH=%PM_PACKAGES_ROOT%\chk\7za\%PM_7ZA_VERSION%
 @if exist "%PM_7Za_PATH%" goto END
 
-@"%PM_PYTHON%" "%PM_MODULE%" install 7za %PM_7za_VERSION% -r packman:s3
+@"%PM_PYTHON%" "%PM_MODULE%" install 7za %PM_7za_VERSION% -r packman:cloudfront
 @if errorlevel 1 goto ERROR
 
 @goto END

--- a/packman/win-bootstrap/fetch_file_from_s3.cmd
+++ b/packman/win-bootstrap/fetch_file_from_s3.cmd
@@ -3,7 +3,7 @@
 @set PACKAGE_NAME=%1
 @set TARGET_PATH=%2
 
-@echo Fetching %PACKAGE_NAME% from s3 ...
+@echo Fetching %PACKAGE_NAME% from S3 ...
 
 @powershell -ExecutionPolicy ByPass -NoLogo -NoProfile -File "%~dp0fetch_file_from_s3.ps1" -sourceName %PACKAGE_NAME% ^
     -output %TARGET_PATH%
@@ -16,7 +16,7 @@
 @exit /b 0
 
 :ERROR_DOWNLOAD_FAILED
-@echo Failed to download file from %1
-@echo Most likely because endpoint cannot be reached (VPN connection down?)
+@echo Failed to download file from S3
+@echo Most likely because endpoint cannot be reached or file %PACKAGE_NAME% doesn't exist
 @endlocal
 @exit /b 1


### PR DESCRIPTION
…ocal storage]

Upgraded to packman 5.1, which uses cloudfront to fetch 7za. This should make the bootstrapping robust.