### PR TITLE
Slang integration fixes

### DIFF
--- a/Framework/Source/Data/Framework/Shaders/TextRenderer.vs.slang
+++ b/Framework/Source/Data/Framework/Shaders/TextRenderer.vs.slang
@@ -29,7 +29,7 @@
 layout(set = 0, binding = 1) cbuffer PerFrameCB : register(b0)
 {
 	float4x4 gvpTransform;
-	float3 gFontColor[2];
+	float3 gFontColor;
 };
 
 float4 transform(float2 posS)

--- a/Framework/Source/Graphics/Program/Program.h
+++ b/Framework/Source/Graphics/Program/Program.h
@@ -116,11 +116,11 @@ namespace Falcor
 
             /** Enable/disable treat-warnings-as-error compilation flag
             */
-            void warningsAsErrors(bool enable) { enable ? shaderFlags |= Shader::CompilerFlags::TreatWarningsAsErrors : shaderFlags &= ~(Shader::CompilerFlags::TreatWarningsAsErrors); }
+            Desc& warningsAsErrors(bool enable) { enable ? shaderFlags |= Shader::CompilerFlags::TreatWarningsAsErrors : shaderFlags &= ~(Shader::CompilerFlags::TreatWarningsAsErrors); return *this; }
 
             /** Enable/disable pre-processed shader dump
             */
-            void dumpIntermediates(bool enable) { enable ? shaderFlags |= Shader::CompilerFlags::DumpIntermediates : shaderFlags &= ~(Shader::CompilerFlags::DumpIntermediates); }
+            Desc& dumpIntermediates(bool enable) { enable ? shaderFlags |= Shader::CompilerFlags::DumpIntermediates : shaderFlags &= ~(Shader::CompilerFlags::DumpIntermediates); return *this; }
 
             /** Get the compiler flags
             */

--- a/Samples/Effects/NormalMapFiltering/Data/NormalMapFiltering.ps.hlsl
+++ b/Samples/Effects/NormalMapFiltering/Data/NormalMapFiltering.ps.hlsl
@@ -43,7 +43,7 @@ float4 main(VertexOut vOut) : SV_TARGET
     [unroll]
     for (uint l = 0; l < _LIGHT_COUNT; l++)
     {
-        result += evalMaterial(sd, gLights[l], 1).color;
+        result += evalMaterial(sd, gLights[l], 1).color.rgb;
     }
 
     result += gAmbient * sd.diffuse;

--- a/Samples/Effects/Shadows/Data/Shadows.ps.hlsl
+++ b/Samples/Effects/Shadows/Data/Shadows.ps.hlsl
@@ -53,7 +53,7 @@ float4 main(ShadowsVSOut pIn) : SV_TARGET0
     for(uint l = 0 ; l < _LIGHT_COUNT ; l++)
     {
         float shadowFactor = calcShadowFactor(gCsmData[l], pIn.shadowsDepthC, sd.posW, pIn.vsData.posH.xy/pIn.vsData.posH.w);
-        color.rgb += evalMaterial(sd, gLights[l], shadowFactor).color;
+        color.rgb += evalMaterial(sd, gLights[l], shadowFactor).color.rgb;
     }
 
     color.rgb += gAmbient * sd.diffuse * 0.1;


### PR DESCRIPTION
These are just two simple issues that I ran into while trying to get Falcor 3.0 to work with the top-of-tree Slang which gets rid of all the various workaround/hand-off compilation paths. There will likely be more changes to come, but these are the ones I could deal with before hitting an issue that requires me to do work inside of Slang instead.

The change to `NormalMapFiltering` might warrant discussion. I'm of the opinion that users will probably appreciate if Slang is more strict than HLSL when it comes to mixing up vectors of different sizes (in this case, trying to add a `float3` and a `float4`), but if it is a high priority to support that code as written, we can file a bug against Slang.