### PR TITLE
Fixing some VK warnings

### DIFF
--- a/Framework/Source/API/CopyContext.cpp
+++ b/Framework/Source/API/CopyContext.cpp
@@ -49,6 +49,7 @@ namespace Falcor
             mpLowLevelData->flush();
             mCommandsPending = false;
         }
+
         bindDescriptorHeaps();
 
         if (wait)

--- a/Framework/Source/API/LowLevel/LowLevelContextData.h
+++ b/Framework/Source/API/LowLevel/LowLevelContextData.h
@@ -48,14 +48,13 @@ namespace Falcor
         ~LowLevelContextData();
 
         static SharedPtr create(CommandQueueType type, CommandQueueHandle queue);
-        virtual void flush();
+        void flush();
 
         CommandListHandle getCommandList() const { return mpList; }
         CommandQueueHandle getCommandQueue() const { return mpQueue; }
         CommandAllocatorHandle getCommandAllocator() const { return mpAllocator; }
         GpuFence::SharedPtr getFence() const { return mpFence; }
         LowLevelContextApiData* getApiData() const { return mpApiData; }
-        void setCommandList(CommandListHandle pList) { mpList = pList; }
 
     protected:
 

--- a/Framework/Source/API/Vulkan/VKRenderContext.cpp
+++ b/Framework/Source/API/Vulkan/VKRenderContext.cpp
@@ -298,7 +298,9 @@ namespace Falcor
             initBlitData<2>(pSrc.get(), srcRect, blt.srcSubresource, blt.srcOffsets);
             initBlitData<2>(pDst.get(), dstRect, blt.dstSubresource, blt.dstOffsets);
 
-            vkCmdBlitImage(mpLowLevelData->getCommandList(), pSrc->getResource()->getApiHandle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, pDst->getResource()->getApiHandle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blt, getVkFilter(filter));
+            // Vulkan spec requires VK_FILTER_NEAREST if blit source is a depth and/or stencil format
+            VkFilter vkFilter = isDepthStencilFormat(pTexture->getFormat()) ? VK_FILTER_NEAREST : getVkFilter(filter);
+            vkCmdBlitImage(mpLowLevelData->getCommandList(), pSrc->getResource()->getApiHandle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, pDst->getResource()->getApiHandle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blt, vkFilter);
         }
     }
 }

--- a/Framework/Source/API/Window.cpp
+++ b/Framework/Source/API/Window.cpp
@@ -353,6 +353,18 @@ namespace Falcor
     {
     }
 
+    void Window::checkWindowSize()
+    {
+        // Actual window size may be clamped to slightly lower than monitor resolution
+        int32_t actualWidth, actualHeight;
+        glfwGetWindowSize(mpGLFWWindow, &actualWidth, &actualHeight);
+
+        mWidth = uint32_t(actualWidth);
+        mHeight = uint32_t(actualHeight);
+        mMouseScale.x = 1.0f / (float)mWidth;
+        mMouseScale.y = 1.0f / (float)mHeight;
+    }
+
     Window::~Window()
     {
         glfwDestroyWindow(mpGLFWWindow);
@@ -380,7 +392,7 @@ namespace Falcor
 
         // Create the window
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-        GLFWmonitor* mon = desc.fullScreen ? glfwGetPrimaryMonitor() :nullptr;
+        GLFWmonitor* mon = desc.fullScreen ? glfwGetPrimaryMonitor() : nullptr;
         GLFWwindow* pGLFWWindow = glfwCreateWindow(desc.width, desc.height, desc.title.c_str(), mon, nullptr);
 
         if (pGLFWWindow == nullptr)
@@ -399,6 +411,7 @@ namespace Falcor
         pWindow->mApiHandle.window = glfwGetX11Window(pGLFWWindow);
         assert(pWindow->mApiHandle.pDisplay != nullptr);
 #endif
+        pWindow->checkWindowSize();
 
         glfwSetWindowUserPointer(pGLFWWindow, pWindow.get());
 
@@ -417,12 +430,7 @@ namespace Falcor
     void Window::resize(uint32_t width, uint32_t height)
     {
         glfwSetWindowSize(mpGLFWWindow, width, height);
-
-        mWidth = width;
-        mHeight = height;
-
-        mMouseScale.x = 1 / float(width);
-        mMouseScale.y = 1 / float(height);
+        checkWindowSize();
 
         mpCallbacks->handleWindowSizeChange();
     }

--- a/Framework/Source/API/Window.h
+++ b/Framework/Source/API/Window.h
@@ -112,7 +112,9 @@ namespace Falcor
 
     private:
         friend class ApiCallbacks;
-        Window(ICallbacks * pCallbacks, uint32_t width, uint32_t height);
+        Window(ICallbacks* pCallbacks, uint32_t width, uint32_t height);
+
+        void checkWindowSize();
 
         GLFWwindow* mpGLFWWindow;
         ApiHandle mApiHandle;


### PR DESCRIPTION
- Call `vkBeginCommandList` on context creation. Fixes #43 
- Fixes blit warning spam in ForwardRenderer sample
- Save actual window resolution after creation. Fixes #42 