### PR TITLE
Added RenderContext::StateBindFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 v3.0.1
 ------
-- 
+- Added RenderContext::StateBindFlags, which allows the user to control which part of the `GraphicsState` will be bound to the pipeline

--- a/Framework/BuildScripts/movedata.bat
+++ b/Framework/BuildScripts/movedata.bat
@@ -28,7 +28,6 @@ robocopy %ExternalsSourceDirectory%\OptiX\bin64 %DestinationDirectory%  *.dll /r
 robocopy %ExternalsSourceDirectory%\openvr\bin\win64 %DestinationDirectory%  openvr_api.dll /r:0 >nul
 robocopy %ExternalsSourceDirectory%\Slang\bin\windows-x64\release %DestinationDirectory%  *.dll /r:0 >nul
 robocopy %ExternalsSourceDirectory%\GLFW\lib %DestinationDirectory%  *.dll /r:0 >nul
-echo %1
 call %1\BuildScripts\moveprojectdata.bat %1\Source\ %DestinationDirectory%
 call %1\BuildScripts\moveprojectdata.bat %3 %DestinationDirectory% /r:0 >nul
 

--- a/Framework/Source/API/D3D12/D3D12RenderContext.cpp
+++ b/Framework/Source/API/D3D12/D3D12RenderContext.cpp
@@ -220,14 +220,17 @@ namespace Falcor
         // Vao must be valid so at least primitive topology is known
         assert(mpGraphicsState->getVao().get());
 
-        // Apply the vars. Must be first because applyGraphicsVars() might cause a flush
-        if (mpGraphicsVars)
+        if (is_set(StateBindFlags::Vars, mBindFlags))
         {
-            applyGraphicsVars();
-        }
-        else
-        {
-            mpLowLevelData->getCommandList()->SetGraphicsRootSignature(RootSignature::getEmpty()->getApiHandle());
+            // Apply the vars. Must be first because applyGraphicsVars() might cause a flush
+            if (mpGraphicsVars)
+            {
+                applyGraphicsVars();
+            }
+            else
+            {
+                mpLowLevelData->getCommandList()->SetGraphicsRootSignature(RootSignature::getEmpty()->getApiHandle());
+            }
         }
 
 #if _ENABLE_NVAPI
@@ -243,12 +246,31 @@ namespace Falcor
         mBindGraphicsRootSig = false;
 
         CommandListHandle pList = mpLowLevelData->getCommandList();
-        pList->IASetPrimitiveTopology(getD3DPrimitiveTopology(mpGraphicsState->getVao()->getPrimitiveTopology()));
-        D3D12SetVao(this, pList, mpGraphicsState->getVao().get());
-        D3D12SetFbo(this, mpGraphicsState->getFbo().get());
-        D3D12SetViewports(pList, &mpGraphicsState->getViewport(0));
-        D3D12SetScissors(pList, &mpGraphicsState->getScissors(0));
-        pList->SetPipelineState(mpGraphicsState->getGSO(mpGraphicsVars.get())->getApiHandle());
+        if (is_set(StateBindFlags::Topology, mBindFlags))
+        {
+            pList->IASetPrimitiveTopology(getD3DPrimitiveTopology(mpGraphicsState->getVao()->getPrimitiveTopology()));
+        }
+        if (is_set(StateBindFlags::Vao, mBindFlags))
+        {
+            D3D12SetVao(this, pList, mpGraphicsState->getVao().get());
+        }
+        if (is_set(StateBindFlags::Fbo, mBindFlags))
+        {
+            D3D12SetFbo(this, mpGraphicsState->getFbo().get());
+        }
+        if (is_set(StateBindFlags::Viewports, mBindFlags))
+        {
+            D3D12SetViewports(pList, &mpGraphicsState->getViewport(0));
+        }
+        if (is_set(StateBindFlags::Scissors, mBindFlags))
+        {
+            D3D12SetScissors(pList, &mpGraphicsState->getScissors(0));
+        }
+        if (is_set(StateBindFlags::PipelineState, mBindFlags))
+        {
+            pList->SetPipelineState(mpGraphicsState->getGSO(mpGraphicsVars.get())->getApiHandle());
+        }
+
         BlendState::SharedPtr blendState = mpGraphicsState->getBlendState();
         if (blendState != nullptr)
         {

--- a/Framework/Source/API/RenderContext.h
+++ b/Framework/Source/API/RenderContext.h
@@ -42,7 +42,6 @@
 
 namespace Falcor
 {
-
     /** The rendering context. Use it to bind state and dispatch calls to the GPU
     */
     class RenderContext : public ComputeContext, public inherit_shared_from_this<ComputeContext, RenderContext>
@@ -52,6 +51,23 @@ namespace Falcor
         using SharedConstPtr = std::shared_ptr<const RenderContext>;
 
         ~RenderContext();
+
+        /**
+            This flag control which aspects of the GraphicState will be bound into the pipeline before drawing.
+            It is useful in cases where the user wants to set a specific object using a raw-API call before calling one of the draw functions
+        */
+        enum class StateBindFlags : uint32_t
+        {
+            None            = 0x0,              ///<Bind Nothing
+            Vars            = 0x1,              ///<Bind Graphics Vars (root signature and sets)
+            Topology        = 0x2,              ///<Bind Primitive Topology
+            Vao             = 0x4,              ///<Bind Vao
+            Fbo             = 0x8,              ///<Bind Fbo
+            Viewports       = 0x10,             ///<Bind Viewport
+            Scissors        = 0x20,             ///<Bind scissors
+            PipelineState   = 0x40,             ///<Bind Pipeline State Object
+            All             = uint32_t(-1)
+        };
 
         /** Create a new object.
         */
@@ -168,6 +184,10 @@ namespace Falcor
         */
         void flush(bool wait = false) override;
 
+        /** Tell the render context what it should and shouldn't bind before drawing
+        */
+        void setBindFlags(StateBindFlags flags) { mBindFlags = flags; }
+
 #ifdef FALCOR_DXR
         /** Submit a raytrace command. This function doesn't change the state of the render-context. Graphics/compute vars and state will stay the same
         */
@@ -193,5 +213,8 @@ namespace Falcor
 
         // Internal functions used by the API layers
         void prepareForDraw();
+        StateBindFlags mBindFlags = StateBindFlags::All;
     };
+
+    enum_class_operators(RenderContext::StateBindFlags);
 }

--- a/Framework/Source/API/Vulkan/VKRenderContext.cpp
+++ b/Framework/Source/API/Vulkan/VKRenderContext.cpp
@@ -190,18 +190,35 @@ namespace Falcor
         assert(mpGraphicsState->getVao().get());
 
         // Apply the vars. Must be first because applyGraphicsVars() might cause a flush
-        if(mpGraphicsVars)
+        if (is_set(RenderContext::StateBindFlags::Vars, mBindFlags))
         {
-            applyGraphicsVars();
+            if (mpGraphicsVars)
+            {
+                applyGraphicsVars();
+            }
         }
 
-        GraphicsStateObject::SharedPtr pGSO = mpGraphicsState->getGSO(mpGraphicsVars.get());
-        vkCmdBindPipeline(mpLowLevelData->getCommandList(), VK_PIPELINE_BIND_POINT_GRAPHICS, pGSO->getApiHandle());
-        
-        transitionFboResources(this, mpGraphicsState->getFbo().get());
-        setViewports(mpLowLevelData->getCommandList(), mpGraphicsState->getViewports());
-        setScissors(mpLowLevelData->getCommandList(), mpGraphicsState->getScissors());
-        setVao(this, mpGraphicsState->getVao().get());
+        if (is_set(RenderContext::StateBindFlags::PipelineState, mBindFlags))
+        {
+            GraphicsStateObject::SharedPtr pGSO = mpGraphicsState->getGSO(mpGraphicsVars.get());
+            vkCmdBindPipeline(mpLowLevelData->getCommandList(), VK_PIPELINE_BIND_POINT_GRAPHICS, pGSO->getApiHandle());
+        }
+        if (is_set(RenderContext::StateBindFlags::Fbo, mBindFlags))
+        {
+            transitionFboResources(this, mpGraphicsState->getFbo().get());
+        }
+        if (is_set(RenderContext::StateBindFlags::Viewports, mBindFlags))
+        {
+            setViewports(mpLowLevelData->getCommandList(), mpGraphicsState->getViewports());
+        }
+        if (is_set(RenderContext::StateBindFlags::Scissors, mBindFlags))
+        {
+            setScissors(mpLowLevelData->getCommandList(), mpGraphicsState->getScissors());
+        }
+        if (is_set(RenderContext::StateBindFlags::Vao, mBindFlags))
+        {
+            setVao(this, mpGraphicsState->getVao().get());
+        }
         beginRenderPass(mpLowLevelData->getCommandList(), mpGraphicsState->getFbo().get());
     }
 


### PR DESCRIPTION
It allows the user to control which parts of the `GraphicsState` will be bound to the pipeline