### PR TITLE
Inform Slang about expected matrix layout convention

### DIFF
--- a/Framework/Source/Graphics/Program/Program.cpp
+++ b/Framework/Source/Graphics/Program/Program.cpp
@@ -397,6 +397,12 @@ namespace Falcor
 
         spSetTargetProfile(slangRequest, 0, spFindProfile(slangSession, getSlangProfileString()));
 
+        // We always use row-major matrix layout (and when we invoke fxc/dxc we pass in the
+        // appropriate flags to request this behavior), so we need to inform Slang that
+        // this is what we want/expect so that it can compute correct reflection information.
+        //
+        spSetTargetMatrixLayoutMode(slangRequest, 0, SLANG_MATRIX_LAYOUT_ROW_MAJOR);
+
         // Configure any flags for the Slang compilation step
         SlangCompileFlags slangFlags = 0;
 

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -29,8 +29,8 @@
         <package name="rapidjson" version="1.1.0" />
     </dependency>
     <dependency name="slang" linkPath="Framework/Externals/Slang">
-        <package name="slang" version="0.10.18" remotes="github-slang" />
-        <package name="slang" version="0.10.18" remotes="github-slang-linux" platforms="linux" />
+        <package name="slang" version="0.10.22" remotes="github-slang" />
+        <package name="slang" version="0.10.22" remotes="github-slang-linux" platforms="linux" />
     </dependency>
     <dependency name="glfw" linkPath="Framework/Externals/GLFW">
         <package name="glfw" version="3.2.1" platforms="win" />


### PR DESCRIPTION
Falcor assumes row-major matrix layout, but Slang currently defaults to column-major conventions when computing layout (this matches fxc/dxc's default behavior).

This PR makes use of new Slang API support to tell Slang to compute layouts using row-major conventions as the default. This requires Slang `v0.10.22`, which is not yet through the release process, since it fixes various issues around code generation with non-default matrix conventions.

Once the new Slang release is ready, this PR should be tested and merged.