### PR TITLE
Use new Slang support for returning "blobs"

### DIFF
--- a/Framework/Source/API/Shader.h
+++ b/Framework/Source/API/Shader.h
@@ -55,10 +55,22 @@ namespace Falcor
         ComPtr(const ThisType& rhs) : mpObject(rhs.mpObject) { if (mpObject) (mpObject)->AddRef(); }
 
         /// Add a new reference to an existing object
-        T* operator=(T* in);
+        T* operator=(T* in)
+        {
+            if(in) in->AddRef();
+            if(mpObject) mpObject->Release();
+            mpObject = in;
+            return in;
+        }
 
         /// Add a new reference to an existing object
-        const ThisType& operator=(const ThisType& rhs);
+        const ThisType& operator=(const ThisType& rhs)
+        {
+            if(rhs.mpObject) rhs.mpObject->AddRef();
+            if(mpObject) mpObject->Release();
+            mpObject = rhs.mpObject;
+            return *this;
+        }
 
         /// Transfer ownership of a reference.
         ComPtr(ThisType&& rhs) : mpObject(rhs.mpObject) { rhs.mpObject = nullptr; }
@@ -67,10 +79,22 @@ namespace Falcor
         ComPtr& operator=(ThisType&& rhs) { ObjectType* swap = mpObject; mpObject = rhs.mpObject; rhs.mpObject = swap; return *this; }
 
         /// Clear out object pointer.
-        void setNull();
+        void setNull()
+        {
+            if( mpObject )
+            {
+                mpObject->Release();
+                mpObject = nullptr;
+            }
+        }
 
         /// Swap pointers with another reference.
-        void swap(ThisType& rhs);
+        void swap(ThisType& rhs)
+        {
+            T* tmp = mpObject;
+            mpObject = rhs.mpObject;
+            rhs.mpObject = tmp;
+        }
 
         /// Get the underlying object pointer.
         T* get() const { return mpObject; }

--- a/Framework/Source/API/Vulkan/VKShader.cpp
+++ b/Framework/Source/API/Vulkan/VKShader.cpp
@@ -37,16 +37,10 @@ namespace Falcor
 
     bool Shader::init(const Blob& shaderBlob, const std::string& entryPointName, CompilerFlags flags, std::string& log)
     {
-        if (shaderBlob.type != Blob::Type::Bytecode)
-        {
-            logError("Vulkan Shaders can only be created from SPIR-V bytecode");
-            return false;
-        }
-
         VkShaderModuleCreateInfo moduleCreateInfo = {};
         moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-        moduleCreateInfo.codeSize = shaderBlob.data.size();
-        moduleCreateInfo.pCode = (uint32_t*)shaderBlob.data.data();
+        moduleCreateInfo.codeSize = shaderBlob->getBufferSize();
+        moduleCreateInfo.pCode = (uint32_t*)shaderBlob->getBufferPointer();
 
         assert(moduleCreateInfo.codeSize % 4 == 0);
 

--- a/Framework/Source/Falcor.props
+++ b/Framework/Source/Falcor.props
@@ -3,7 +3,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
     <FALCOR_CORE_DIRECTORY>$(SolutionDir)\.\Framework\Source\\..\</FALCOR_CORE_DIRECTORY>
-    <FALCOR_BACKEND>FALCOR_D3D12</FALCOR_BACKEND>
+    <FALCOR_BACKEND>FALCOR_VK</FALCOR_BACKEND>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir>$(SolutionDir)Bin\$(PlatformShortName)\$(Configuration)\</OutDir>

--- a/Framework/Source/Graphics/Program/Program.cpp
+++ b/Framework/Source/Graphics/Program/Program.cpp
@@ -456,7 +456,6 @@ namespace Falcor
         preprocessorDefine = "FALCOR_D3D";
         // If the profile string starts with a `4_` or a `5_`, use DXBC. Otherwise, use DXIL
         if (hasPrefix(mDesc.mShaderModel, "4_") || hasPrefix(mDesc.mShaderModel, "5_")) slangTarget = SLANG_DXBC;
-        else if (mDesc.mShaderModel == "6_3")                                           slangTarget = SLANG_HLSL;   // TODO This is actually a hack for DXR, we need to fix it
         else                                                                            slangTarget = SLANG_DXIL;
 #else
 #error unknown shader compilation target
@@ -547,21 +546,10 @@ namespace Falcor
                 continue;
 
             int entryPointIndex = entryPointCounter++;
+            int targetIndex = 0; // We always compile for a single target
 
-            if (slangTarget == SLANG_GLSL || slangTarget == SLANG_GLSL_VULKAN || slangTarget == SLANG_HLSL)
-            {
-                shaderBlob[i].type = Shader::Blob::Type::String;
-                const char* data = spGetEntryPointSource(slangRequest, entryPointIndex);
-                shaderBlob[i].data.assign(data, data + strlen(data));
-            }
-            else
-            {
-                shaderBlob[i].type = Shader::Blob::Type::Bytecode;
-                size_t size = 0;
-                const uint8_t* data = (uint8_t*)spGetEntryPointCode(slangRequest, entryPointIndex, &size);
-                shaderBlob[i].data.assign(data, data + size);
-            }
-            shaderBlob[i].shaderModel = mDesc.mShaderModel;
+            ISlangBlob* blob = spGetEntryPointCodeBlob(slangRequest, entryPointIndex, targetIndex);
+            shaderBlob[i].attach(blob);
         }
 
         VersionData programVersion;
@@ -594,7 +582,7 @@ namespace Falcor
         Shader::SharedPtr shaders[kShaderCount] = {};
         for (uint32_t i = 0; i < kShaderCount; i++)
         {
-            if (shaderBlob[i].data.size())
+            if (shaderBlob[i])
             { 
                 shaders[i] = createShaderFromBlob(shaderBlob[i], ShaderType(i), mDesc.mEntryPoints[i].name, mDesc.getCompilerFlags(), log);
                 if (!shaders[i]) return nullptr;

--- a/Framework/Source/Graphics/Program/Program.cpp
+++ b/Framework/Source/Graphics/Program/Program.cpp
@@ -548,8 +548,7 @@ namespace Falcor
             int entryPointIndex = entryPointCounter++;
             int targetIndex = 0; // We always compile for a single target
 
-            ISlangBlob* blob = spGetEntryPointCodeBlob(slangRequest, entryPointIndex, targetIndex);
-            shaderBlob[i].attach(blob);
+            spGetEntryPointCodeBlob(slangRequest, entryPointIndex, targetIndex, shaderBlob[i].writeRef());
         }
 
         VersionData programVersion;

--- a/Framework/Source/Raytracing/RtProgram/HitProgram.cpp
+++ b/Framework/Source/Raytracing/RtProgram/HitProgram.cpp
@@ -60,7 +60,7 @@ namespace Falcor
 
     // #DXR_FIX add the filename
 #define create_shader(_type, _pshader)                          \
-    if (shaderBlob[uint32_t(_type)].data.size())                \
+    if (shaderBlob[uint32_t(_type)])                            \
     {                                                           \
         _pshader = createRtShaderFromBlob(                      \
         mDesc.getShaderLibrary(_type)->getFilename(),            \

--- a/Framework/Source/Raytracing/RtShader.cpp
+++ b/Framework/Source/Raytracing/RtShader.cpp
@@ -49,48 +49,8 @@ namespace Falcor
         return pShader->init(shaderBlob, entryPointName, flags, log) ? pShader : nullptr;
     }
 
-    ID3DBlobPtr RtShader::compile(const Blob& blob, const std::string&  entryPointName, Shader::CompilerFlags flags, std::string& log)
-    {
-        d3d_call(gDxrDllHelper.Initialize());
-        IDxcCompilerPtr pCompiler;
-        IDxcLibraryPtr pLibrary;
-        d3d_call(gDxrDllHelper.CreateInstance(CLSID_DxcCompiler, &pCompiler));
-        d3d_call(gDxrDllHelper.CreateInstance(CLSID_DxcLibrary, &pLibrary));
-
-        // Create blob from the string
-        IDxcBlobEncodingPtr pTextBlob;
-        d3d_call(pLibrary->CreateBlobWithEncodingFromPinned((LPBYTE)blob.data.data(), (uint32_t)blob.data.size(), 0, &pTextBlob));
-
-        // Compile
-        std::vector<const WCHAR*> argv;
-        argv.push_back(L"-Zpr");
-        if (is_set(flags, Shader::CompilerFlags::TreatWarningsAsErrors))
-        {
-            argv.push_back(L"-WX");
-        }
-        IDxcOperationResultPtr pResult;
-        std::wstring entryPoint = string_2_wstring(entryPointName);
-        d3d_call(pCompiler->Compile(pTextBlob, L"RT Shader", L"", L"lib_6_3", argv.size() ? argv.data() : nullptr, (uint32_t)argv.size(), nullptr, 0, nullptr, &pResult));
-
-        // Verify the result
-        HRESULT resultCode;
-        d3d_call(pResult->GetStatus(&resultCode));
-        if (FAILED(resultCode))
-        {
-            IDxcBlobEncodingPtr pError;
-            d3d_call(pResult->GetErrorBuffer(&pError));
-            log += convertBlobToString(pError.GetInterfacePtr());
-            return nullptr;
-        }
-
-        IDxcBlobPtr pBlob;
-        d3d_call(pResult->GetResult(&pBlob));
-        return pBlob;
-    }
-
     RtShader::SharedPtr createRtShaderFromBlob(const std::string& filename, const std::string& entryPoint, const Shader::Blob& blob, Shader::CompilerFlags flags, ShaderType shaderType, std::string& log)
     {
-        assert(blob.type == Shader::Blob::Type::String);
         std::string msg;
         RtShader::SharedPtr pShader = RtShader::create(blob, entryPoint, shaderType, flags, msg);
 

--- a/Framework/Source/Raytracing/RtShader.h
+++ b/Framework/Source/Raytracing/RtShader.h
@@ -47,7 +47,6 @@ namespace Falcor
     private:
         RtShader(ShaderType type, const std::string& entryPointName);
         std::string mEntryPoint;
-        ID3DBlobPtr compile(const Blob& blob, const std::string&  entryPointName, Shader::CompilerFlags flags, std::string& errorLog) override;
     };
 
     RtShader::SharedPtr createRtShaderFromBlob(


### PR DESCRIPTION
This change relies on new Slang API support for returning output code in the form of "blobs" that are compatible with the `ID3DBlob` (`ID3D10Blob`, `IDxcBlob`) interface.

Hilights:

* The `SlangBlob` type is gone. There is no need for Falcor to wrap up raw data in a blob, because Slang can return blobs already.

* `Shader::compile` and `RtShader::compile` are gone. There are no more calls to fxc or dxc left in Falcor, because Slang takes responsibility for them.

* A new type `ComPtr<T>` is introduced because now we need to work with COM-compatible pointers even when on non-Windows platforms. This currently defines more methods than are used (or implemented) so it could be streamlined if needed.

* The `Shader::Blob` has been replaced with a `typedef` for `ComPtr<ISlangBlob>`. That is, all uses of `Shader::Blob` are now just uses of a reference-counted blob pointer.

* The logic for extracting code from Slang is streamlined: we are always getting back binary data, and it is always done with `spGetEntryPointCodeBlob`. Note: if in the future we need source code back, that is fine becasue `spGetEntryPointCodeBlob` can also return the output source code.