### PR TITLE
Do not catch polymorphic types by value

### DIFF
--- a/Framework/Source/ArgList.cpp
+++ b/Framework/Source/ArgList.cpp
@@ -73,7 +73,7 @@ namespace Falcor
         {
             return mMap.at(key);
         }
-        catch(std::out_of_range)
+        catch(const std::out_of_range&)
         {
             return std::vector<ArgList::Arg>();
         }


### PR DESCRIPTION
Addresses an error reported by clang 6.0.0 when compiling on Linux.