### PR TITLE
Support explicit LODs in prepareShadingData

### DIFF
--- a/Framework/Source/ShadingUtils/Shading.slang
+++ b/Framework/Source/ShadingUtils/Shading.slang
@@ -34,24 +34,67 @@ __import Lights;
 __import BRDF;
 __import Helpers;
 
-/** Load data from a texture
+
+/** Interface for texture LOD computation techniques.
+
+Types implementing this interface support computing level-of-detail
+values suitable for performing texture fetches.
 */
-float4 sampleTexture(Texture2D t, SamplerState s, float2 uv, float4 factor, uint mode)
+interface ITextureLOD
 {
-    if(mode == ChannelTypeUnused) return 0;
-    if(mode == ChannelTypeConst) return factor;
-    // else mode == ChannelTypeTexture
-    return t.Sample(s, uv);
-}
+    /** Sample from a 2D texture using the level of detail computed
+    by this method
+    */
+    float4 sampleTexture(Texture2D t, SamplerState s, float2 uv);
+};
+
+/** Texture LOD computation using implicit fragment-quad finite differences
+*/
+struct ImplicitTextureLOD : ITextureLOD
+{
+    float4 sampleTexture(Texture2D t, SamplerState s, float2 uv)
+    {
+        return t.Sample(s, uv);
+    }
+};
+
+/** Texture LOD computation using an explicit scalar level of detail
+*/
+struct ExplicitTextureLOD : ITextureLOD
+{
+    float lod; ///< The explicit level of detail to use
+
+    float4 sampleTexture(Texture2D t, SamplerState s, float2 uv)
+    {
+        return t.SampleLevel(s, uv, lod);
+    }
+};
+
+/** Texture LOD computation using explicit screen-space gradients
+*/
+struct ExplicitGradientTextureLOD : ITextureLOD
+{
+    float2 gradX; ///< Gradient of texture coordinate in the screen-space X direction
+    float2 gradY; ///< Gradient of texture coordiante in teh screen-space Y direction
+
+    float4 sampleTexture(Texture2D t, SamplerState s, float2 uv)
+    {
+        return t.SampleGrad(s, uv, gradX, gradY);
+    }
+};
+
 
 /** Load data from a texture
+
+The `lod` parameter represents the method to use for computing
+texture level of detail, and must implement the `ITextureLOD` interface.
 */
-float4 sampleTexture(Texture2D t, SamplerState s, float2 uv, float4 factor, uint mode, float lod)
+float4 sampleTexture<L:ITextureLOD>(Texture2D t, SamplerState s, float2 uv, float4 factor, uint mode, L lod)
 {
     if(mode == ChannelTypeUnused) return 0;
     if(mode == ChannelTypeConst) return factor;
     // else mode == ChannelTypeTexture
-    return t.SampleLevel(s, uv, lod);
+    return lod.sampleTexture(t, s, uv);
 }
 
 /** Shading result struct
@@ -87,13 +130,16 @@ float3 RgToNormal(float2 rg)
 }
 
 /** Apply normal map
+
+The `lod` parameter represents the method to use for computing
+texture level of detail, and must implement the `ITextureLOD` interface.
 */
-void applyNormalMap(MaterialData m, inout ShadingData sd)
+void applyNormalMap<L:ITextureLOD>(MaterialData m, inout ShadingData sd, L lod)
 {
     uint mapType = EXTRACT_NORMAL_MAP_TYPE(m.flags);
     if(mapType == NormalMapUnused) return;
 
-    float3 mapN = m.resources.normalMap.Sample(m.resources.samplerState, sd.uv).rgb;
+    float3 mapN = lod.sampleTexture(m.resources.normalMap, m.resources.samplerState, sd.uv).xyz;
     switch(mapType)
     {
     case NormalMapRGB:
@@ -137,9 +183,12 @@ ShadingData initShadingData()
     return sd;
 }
 
-/** Prepare the hit-point data
+/** Internal implementation of `prepareShadingData`
+
+The `lod` parameter represents the method to use for computing
+texture level of detail, and must implement the `ITextureLOD` interface.
 */
-ShadingData prepareShadingData(VertexOut v, MaterialData m, float3 camPosW)
+ShadingData _prepareShadingData<L:ITextureLOD>(VertexOut v, MaterialData m, float3 camPosW, L lod)
 {
     ShadingData sd = initShadingData();
 
@@ -148,7 +197,7 @@ ShadingData prepareShadingData(VertexOut v, MaterialData m, float3 camPosW)
 #endif
 
     // Sample the diffuse texture and apply the alpha test
-    float4 baseColor = sampleTexture(m.resources.baseColor, m.resources.samplerState, v.texC, m.baseColor, EXTRACT_DIFFUSE_TYPE(m.flags));
+    float4 baseColor = sampleTexture(m.resources.baseColor, m.resources.samplerState, v.texC, m.baseColor, EXTRACT_DIFFUSE_TYPE(m.flags), lod);
     sd.opacity = m.baseColor.a;
     alphaTest(m.flags, baseColor.a, m.alphaThreshold, v.posW);
 
@@ -162,7 +211,7 @@ ShadingData prepareShadingData(VertexOut v, MaterialData m, float3 camPosW)
 
     // Sample the spec texture
     bool sampleOcclusion = EXTRACT_OCCLUSION_MAP(m.flags) > 0;
-    float4 spec = sampleTexture(m.resources.specular, m.resources.samplerState, v.texC, m.specular, EXTRACT_SPECULAR_TYPE(m.flags));
+    float4 spec = sampleTexture(m.resources.specular, m.resources.samplerState, v.texC, m.specular, EXTRACT_SPECULAR_TYPE(m.flags), lod);
     if(EXTRACT_SHADING_MODEL(m.flags) == ShadingModelMetalRough)
     {
         // R - Occlusion; G - Roughness; B - Metalness
@@ -182,23 +231,23 @@ ShadingData prepareShadingData(VertexOut v, MaterialData m, float3 camPosW)
 
         if(sampleOcclusion)
         {
-            sd.occlusion = sampleTexture(m.resources.occlusionMap, m.resources.samplerState, v.texC, 1, ChannelTypeTexture);
+            sd.occlusion = sampleTexture(m.resources.occlusionMap, m.resources.samplerState, v.texC, 1, ChannelTypeTexture, lod);
         }
     }
 
     sd.linearRoughness = max(0.08, sd.linearRoughness); // Clamp the roughness so that the BRDF won't explode
     sd.roughness = sd.linearRoughness * sd.linearRoughness;
-    sd.emissive = sampleTexture(m.resources.emissive, m.resources.samplerState, v.texC, float4(m.emissive, 1), EXTRACT_EMISSIVE_TYPE(m.flags)).rgb;
+    sd.emissive = sampleTexture(m.resources.emissive, m.resources.samplerState, v.texC, float4(m.emissive, 1), EXTRACT_EMISSIVE_TYPE(m.flags), lod).rgb;
     sd.IoR = m.IoR;
     sd.doubleSidedMaterial = EXTRACT_DOUBLE_SIDED(m.flags);
 
 #define channel_type(extract) (extract(m.flags) ? ChannelTypeTexture : ChannelTypeUnused)
-    sd.lightMap = sampleTexture(m.resources.lightMap, m.resources.samplerState, v.lightmapC, 1, channel_type(EXTRACT_LIGHT_MAP)).rgb;
-    sd.height = sampleTexture(m.resources.heightMap, m.resources.samplerState, v.texC, 1, channel_type(EXTRACT_HEIGHT_MAP)).xy;
+    sd.lightMap = sampleTexture(m.resources.lightMap, m.resources.samplerState, v.lightmapC, 1, channel_type(EXTRACT_LIGHT_MAP), lod).rgb;
+    sd.height = sampleTexture(m.resources.heightMap, m.resources.samplerState, v.texC, 1, channel_type(EXTRACT_HEIGHT_MAP), lod).xy;
     sd.height = sd.height * m.heightScaleOffset.x + m.heightScaleOffset.y;
 #undef channel_type
     
-    applyNormalMap(m, sd);
+    applyNormalMap(m, sd, lod);
     sd.NdotV = dot(sd.N, sd.V);
 
     // Flip the normal if it's backfacing
@@ -209,6 +258,37 @@ ShadingData prepareShadingData(VertexOut v, MaterialData m, float3 camPosW)
     }
 
     return sd;
+}
+
+/** Prepare the hit-point data
+*/
+ShadingData prepareShadingData(VertexOut v, MaterialData m, float3 camPosW)
+{
+    ImplicitTextureLOD lod = {};
+    return _prepareShadingData(v, m, camPosW, lod);
+}
+
+/** Prepare the hit-point data
+
+The `lod` parameter represents the level of detail to use for all material
+texture fetches.
+*/
+ShadingData prepareShadingData(VertexOut v, MaterialData m, float3 camPosW, float lod)
+{
+    ExplicitTextureLOD explicitLOD = { lod };
+    return _prepareShadingData(v, m, camPosW, explicitLOD);
+}
+
+/** Prepare the hit-point data
+
+The `gradX` and `gradY` parameters should be the screen-space gradients of
+`v.texC` with respect to screen-space X and Y, respectively. These gradient
+values will be used for all material texture fetches.
+*/
+ShadingData prepareShadingData(VertexOut v, MaterialData m, float3 camPosW, float2 gradX, float2 gradY)
+{
+    ExplicitGradientTextureLOD lod = { gradX, gradY };
+    return _prepareShadingData(v, m, camPosW, lod);
 }
 
 ShadingResult initShadingResult()

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ The HelloDXR sample demonstrates how to use Falcor’s DXR abstraction layer.
     - Windows 10 RS4 (version 1803)
     - Windows 10 Developer Mode enabled (Windows Settings -> Update & Security -> For developers -> Developer mode)
     - You do not need to download the DXR SDK yourself, it is packaged with Falcor.
-    - A GPU which supports DirectX Raytracing, such as the NVIDIA Titan V
-    - NVIDIA driver version 397.31 or later
+    - A GPU which supports DirectX Raytracing, such as the NVIDIA Titan V or GeForce RTX (make sure you have the latest driver).
 
 Currently, Falcor doesn’t support the DXR fallback layer. We will add support for it in the near future.  
 Please note that the DXR abstraction layer is considererd an experimental feature, just like DXR itself. The interfaces and features might change in future releases.


### PR DESCRIPTION
In the past, `prepareShadingData()` could be configured via `#define`s to accept explicit user-defined gradients for the texture coordinate used to sample material textures. This define-based configuration was dropped, but users still need a way to pass down explicit LOD information for applications like ray tracing (where implicit screen-space derivatives over fragment quads don't apply).

From the Falcor user's perspective, this change introduces two new overloads of `prepareShadingData`. One new overload takes an additional `float lod` parameter to use as an explicit LOD (material textures will be fetched with `SampleLevel`). The other takes two additional parameters, `float2 gradX` and `float2 gradY`, which represent the screen-space gradients of the texture coordinate (material textures will be fetched with `SampleGrad`).

From an implementor's perspective, all three of the overloads for `prepareShadingData` bottleneck through a single function written using Slang generics. The generic type parameter represents a texture LOD computation method, codified for now with the interface `ITextureLOD`. There are three implementations of this interface to cover the three different cases: implicit LODs, explicit scalar LOD, and explicit gradients.

The two `sampleTexture()` overloads in the original code were rewritten to a single generic version (eliminating some minor code duplication), and `applyNormalMap()` was also made generic because it was performing an implicit-LOD texture fetch. These routines appear to be implementation details of `prepareShadingData()`, but if they are intended to be public API of the Falcor shading system, then we probably need to provide non-generic overloads for them akin to what was done for `prepareShadingData()`.

I tested this under D3D12 by tweaking the `prepareShadingData()` call site in the ForwardRenderer example to use an explicit LOD and then explicit gradients. I have *not* yet tested this under Vulkan.