### PR TITLE
Initial support for "Shader Components"

### DIFF
--- a/Framework/Source/API/ComputeContext.cpp
+++ b/Framework/Source/API/ComputeContext.cpp
@@ -89,15 +89,16 @@ namespace Falcor
         mpComputeStateStack.pop();
     }
 
-    void ComputeContext::applyComputeVars() 
+    void ComputeContext::applyComputeVars(const ProgramKernels* pKernels) 
     {
-        if (mpComputeVars->apply(const_cast<ComputeContext*>(this), mBindComputeRootSig) == false)
+        if (mpComputeVars->apply(const_cast<ComputeContext*>(this), mBindComputeRootSig, pKernels) == false)
         {
             logWarning("ComputeContext::prepareForDispatch() - applying ComputeVars failed, most likely because we ran out of descriptors. Flushing the GPU and retrying");
             flush(true);
-            bool b = mpComputeVars->apply(const_cast<ComputeContext*>(this), mBindComputeRootSig);
+            bool b = mpComputeVars->apply(const_cast<ComputeContext*>(this), true, pKernels);
             assert(b);
         }
+        mBindComputeRootSig = false;
     }
     
     void ComputeContext::flush(bool wait)

--- a/Framework/Source/API/ComputeContext.h
+++ b/Framework/Source/API/ComputeContext.h
@@ -105,11 +105,12 @@ namespace Falcor
     protected:
         ComputeContext();
         void prepareForDispatch();
-        void applyComputeVars();
+        void applyComputeVars(const ProgramKernels* pKernels);
 
         std::stack<ComputeState::SharedPtr> mpComputeStateStack;
         std::stack<ComputeVars::SharedPtr> mpComputeVarsStack;
         bool mBindComputeRootSig = true;
+        RootSignature::SharedPtr mpComputeRootSignature;
 
         ComputeVars::SharedPtr mpComputeVars;
         ComputeState::SharedPtr mpComputeState;

--- a/Framework/Source/API/ComputeStateObject.h
+++ b/Framework/Source/API/ComputeStateObject.h
@@ -46,12 +46,12 @@ namespace Falcor
         {
         public:
             Desc& setRootSignature(RootSignature::SharedPtr pSignature) { mpRootSignature = pSignature; return *this; }
-            Desc& setProgramVersion(ProgramVersion::SharedConstPtr pProgram) { mpProgram = pProgram; return *this; }
-            ProgramVersion::SharedConstPtr getProgramVersion() const { return mpProgram; }
+            Desc& setProgramKernels(ProgramKernels::SharedConstPtr pProgram) { mpProgram = pProgram; return *this; }
+            ProgramKernels::SharedConstPtr getProgramKernels() const { return mpProgram; }
             bool operator==(const Desc& other) const;
         private:
             friend class ComputeStateObject;
-            ProgramVersion::SharedConstPtr mpProgram;
+            ProgramKernels::SharedConstPtr mpProgram;
             RootSignature::SharedPtr mpRootSignature;
         };
 

--- a/Framework/Source/API/D3D12/D3D12ComputeContext.cpp
+++ b/Framework/Source/API/D3D12/D3D12ComputeContext.cpp
@@ -37,17 +37,25 @@ namespace Falcor
     {
         assert(mpComputeState);
 
+        auto pCSO = mpComputeState->getCSO(mpComputeVars.get());
+        auto pComputeKernels = pCSO->getDesc().getProgramKernels();
+        auto pRootSignature = pComputeKernels->getRootSignature();
+        if( pRootSignature != mpComputeRootSignature )
+        {
+            mpComputeRootSignature = pRootSignature;
+            mBindComputeRootSig = true;
+        }
+
         // Apply the vars. Must be first because applyComputeVars() might cause a flush        
         if (mpComputeVars)
         {
-            applyComputeVars();
+            applyComputeVars(pComputeKernels.get());
         }
         else
         {
             mpLowLevelData->getCommandList()->SetComputeRootSignature(RootSignature::getEmpty()->getApiHandle());
         }
-        mBindComputeRootSig = false;
-        mpLowLevelData->getCommandList()->SetPipelineState(mpComputeState->getCSO(mpComputeVars.get())->getApiHandle());
+        mpLowLevelData->getCommandList()->SetPipelineState(pCSO->getApiHandle());
         mCommandsPending = true;
     }
 

--- a/Framework/Source/API/D3D12/D3D12State.cpp
+++ b/Framework/Source/API/D3D12/D3D12State.cpp
@@ -472,8 +472,8 @@ namespace Falcor
     void initD3D12GraphicsStateDesc(const GraphicsStateObject::Desc& gsoDesc, D3D12_GRAPHICS_PIPELINE_STATE_DESC& desc, InputLayoutDesc& layoutDesc)
     {
         desc = {};
-        assert(gsoDesc.getProgramVersion());
-#define get_shader_handle(_type) gsoDesc.getProgramVersion()->getShader(_type) ? gsoDesc.getProgramVersion()->getShader(_type)->getApiHandle() : D3D12_SHADER_BYTECODE{}
+        assert(gsoDesc.getProgramKernels());
+#define get_shader_handle(_type) gsoDesc.getProgramKernels()->getShader(_type) ? gsoDesc.getProgramKernels()->getShader(_type)->getApiHandle() : D3D12_SHADER_BYTECODE{}
         desc.VS = get_shader_handle(ShaderType::Vertex);
         desc.PS = get_shader_handle(ShaderType::Pixel);
         desc.GS = get_shader_handle(ShaderType::Geometry);

--- a/Framework/Source/API/D3D12/D3DProgramVersion.cpp
+++ b/Framework/Source/API/D3D12/D3DProgramVersion.cpp
@@ -33,12 +33,12 @@
 
 namespace Falcor
 {
-    void ProgramVersion::deleteApiHandle()
+    void ProgramKernels::deleteApiHandle()
     {
 
     }
 
-    bool ProgramVersion::init(std::string& log)
+    bool ProgramKernels::init(std::string& log)
     {
         return true;
     }

--- a/Framework/Source/API/GraphicsStateObject.h
+++ b/Framework/Source/API/GraphicsStateObject.h
@@ -68,7 +68,7 @@ namespace Falcor
             Desc& setRootSignature(RootSignature::SharedPtr pSignature) { mpRootSignature = pSignature; return *this; }
             Desc& setVertexLayout(VertexLayout::SharedConstPtr pLayout) { mpLayout = pLayout; return *this; }
             Desc& setFboFormats(const Fbo::Desc& fboFormats) { mFboDesc = fboFormats; return *this; }
-            Desc& setProgramVersion(ProgramVersion::SharedConstPtr pProgram) { mpProgram = pProgram; return *this; }
+            Desc& setProgramKernels(ProgramKernels::SharedConstPtr pProgram) { mpProgram = pProgram; return *this; }
             Desc& setBlendState(BlendState::SharedPtr pBlendState) { mpBlendState = pBlendState; return *this; }
             Desc& setRasterizerState(RasterizerState::SharedPtr pRasterizerState) { mpRasterizerState = pRasterizerState; return *this; }
             Desc& setDepthStencilState(DepthStencilState::SharedPtr pDepthStencilState) { mpDepthStencilState = pDepthStencilState; return *this; }
@@ -83,7 +83,7 @@ namespace Falcor
             GraphicsStateObject::PrimitiveType getPrimitiveType() const { return mPrimType; }
             VertexLayout::SharedConstPtr getVertexLayout() const { return mpLayout; }
             Fbo::Desc getFboDesc() const { return mFboDesc; }
-            ProgramVersion::SharedConstPtr getProgramVersion() const { return mpProgram; }
+            ProgramKernels::SharedConstPtr getProgramKernels() const { return mpProgram; }
             RootSignature::SharedPtr getRootSignature() const { return mpRootSignature; }
 
             bool getSinglePassStereoEnabled() const { return mSinglePassStereoEnabled; }
@@ -94,7 +94,7 @@ namespace Falcor
             friend class GraphicsStateObject;
             VertexLayout::SharedConstPtr mpLayout;
             Fbo::Desc mFboDesc;
-            ProgramVersion::SharedConstPtr mpProgram;
+            ProgramKernels::SharedConstPtr mpProgram;
             RasterizerState::SharedPtr mpRasterizerState;
             DepthStencilState::SharedPtr mpDepthStencilState;
             BlendState::SharedPtr mpBlendState;

--- a/Framework/Source/API/RenderContext.cpp
+++ b/Framework/Source/API/RenderContext.cpp
@@ -108,15 +108,16 @@ namespace Falcor
         }
     }
 
-    void RenderContext::applyGraphicsVars()
+    void RenderContext::applyGraphicsVars(const ProgramKernels* pKernels)
     {
-        if (mpGraphicsVars->apply(const_cast<RenderContext*>(this), mBindGraphicsRootSig) == false)
+        if (mpGraphicsVars->apply(const_cast<RenderContext*>(this), mBindGraphicsRootSig, pKernels) == false)
         {
             logWarning("RenderContext::prepareForDraw() - applying GraphicsVars failed, most likely because we ran out of descriptors. Flushing the GPU and retrying");
             flush(true);
-            bool b = mpGraphicsVars->apply(const_cast<RenderContext*>(this), mBindGraphicsRootSig);
+            bool b = mpGraphicsVars->apply(const_cast<RenderContext*>(this), true, pKernels);
             assert(b);
         }
+        mBindGraphicsRootSig = false;
     }
 
     void RenderContext::flush(bool wait)

--- a/Framework/Source/API/RenderContext.h
+++ b/Framework/Source/API/RenderContext.h
@@ -201,7 +201,7 @@ namespace Falcor
 #ifdef FALCOR_DXR
         /** Submit a raytrace command. This function doesn't change the state of the render-context. Graphics/compute vars and state will stay the same
         */
-        void raytrace(std::shared_ptr<RtProgramVars> pVars, std::shared_ptr<RtState> pState, uint32_t width, uint32_t height);
+        void raytrace(std::shared_ptr<RtProgramVars> pVars, std::shared_ptr<RtStateObject> pRtso, uint32_t width, uint32_t height);
 #endif
 
     private:
@@ -209,6 +209,7 @@ namespace Falcor
         GraphicsVars::SharedPtr mpGraphicsVars;
         GraphicsState::SharedPtr mpGraphicsState;
         bool mBindGraphicsRootSig = true;
+        RootSignature::SharedPtr mpGraphicsRootSignature;
 
         std::stack<GraphicsState::SharedPtr> mPipelineStateStack;
         std::stack<GraphicsVars::SharedPtr> mpGraphicsVarsStack;
@@ -220,7 +221,7 @@ namespace Falcor
         compute context's initDispatchCommandSignature() to create command signature for dispatchIndirect
         */
         static void initDrawCommandSignatures();
-        void applyGraphicsVars();
+        void applyGraphicsVars(const ProgramKernels* pKernels);
 
         // Internal functions used by the API layers
         void prepareForDraw();

--- a/Framework/Source/API/Vulkan/VKComputeContext.cpp
+++ b/Framework/Source/API/Vulkan/VKComputeContext.cpp
@@ -36,11 +36,19 @@ namespace Falcor
     void ComputeContext::prepareForDispatch()
     {
         assert(mpComputeState);
-        if(mpComputeVars) applyComputeVars();
 
         ComputeStateObject::SharedPtr pCso = mpComputeState->getCSO(mpComputeVars.get());
+        auto pComputeKernels = pCso->getDesc().getProgramKernels();
+        auto pRootSignature = pComputeKernels->getRootSignature();
+        if( pRootSignature != mpComputeRootSignature )
+        {
+            mpComputeRootSignature = pRootSignature;
+            mBindComputeRootSig = true;
+        }
+
+        if(mpComputeVars) applyComputeVars(pComputeKernels.get());
+
         vkCmdBindPipeline(mpLowLevelData->getCommandList(), VK_PIPELINE_BIND_POINT_COMPUTE, pCso->getApiHandle());
-        mBindComputeRootSig = false;
         mCommandsPending = true;
     }
 

--- a/Framework/Source/API/Vulkan/VKComputeStateObject.cpp
+++ b/Framework/Source/API/Vulkan/VKComputeStateObject.cpp
@@ -35,7 +35,7 @@ namespace Falcor
     bool ComputeStateObject::apiInit()
     {
         std::vector<VkPipelineShaderStageCreateInfo> shaderStageInfos;
-        initVkShaderStageInfo(mDesc.getProgramVersion().get(), shaderStageInfos);
+        initVkShaderStageInfo(mDesc.getProgramKernels().get(), shaderStageInfos);
         assert(shaderStageInfos.size() == 1);
 
         VkComputePipelineCreateInfo info = {};

--- a/Framework/Source/API/Vulkan/VKGraphicsStateObject.cpp
+++ b/Framework/Source/API/Vulkan/VKGraphicsStateObject.cpp
@@ -38,11 +38,11 @@ namespace Falcor
     {
         // Shader Stages
         std::vector<VkPipelineShaderStageCreateInfo> shaderStageInfos;
-        initVkShaderStageInfo(mDesc.getProgramVersion().get(), shaderStageInfos);
+        initVkShaderStageInfo(mDesc.getProgramKernels().get(), shaderStageInfos);
 
         // Vertex Input State
         VertexInputStateCreateInfo vertexInputInfo = {};
-        initVkVertexLayoutInfo(mDesc.getVertexLayout().get(), vertexInputInfo, mDesc.getProgramVersion()->getReflector().get());
+        initVkVertexLayoutInfo(mDesc.getVertexLayout().get(), vertexInputInfo, mDesc.getProgramKernels()->getReflector().get());
 
         // Input Assembly State
         VkPipelineInputAssemblyStateCreateInfo inputAssemblyInfo = {};
@@ -61,7 +61,7 @@ namespace Falcor
 
         // Multisample State
         VkPipelineMultisampleStateCreateInfo multisampleInfo = {};
-        bool enableSampleFrequency = mDesc.getProgramVersion() ? mDesc.getProgramVersion()->getReflector()->isSampleFrequency() : false;
+        bool enableSampleFrequency = mDesc.getProgramKernels() ? mDesc.getProgramKernels()->getReflector()->isSampleFrequency() : false;
         initVkMultiSampleInfo(mDesc.getBlendState().get(), mDesc.getFboDesc(), mDesc.getSampleMask(), multisampleInfo, enableSampleFrequency);
 
         // Depth Stencil State

--- a/Framework/Source/API/Vulkan/VKProgramVersion.cpp
+++ b/Framework/Source/API/Vulkan/VKProgramVersion.cpp
@@ -30,12 +30,12 @@
 
 namespace Falcor
 {
-    void ProgramVersion::deleteApiHandle()
+    void ProgramKernels::deleteApiHandle()
     {
 
     }
 
-    bool ProgramVersion::init(std::string& log)
+    bool ProgramKernels::init(std::string& log)
     {
         return true;
     }

--- a/Framework/Source/API/Vulkan/VKRenderContext.cpp
+++ b/Framework/Source/API/Vulkan/VKRenderContext.cpp
@@ -190,18 +190,26 @@ namespace Falcor
         // Vao must be valid so at least primitive topology is known
         assert(mpGraphicsState->getVao().get());
 
+        GraphicsStateObject::SharedPtr pGSO = mpGraphicsState->getGSO(mpGraphicsVars.get());
+        auto pGraphicsKernels = pGSO->getDesc().getProgramKernels();
+        auto pRootSignature = pGraphicsKernels->getRootSignature();
+        if( pRootSignature != mpGraphicsRootSignature )
+        {
+            mpGraphicsRootSignature = pRootSignature;
+            mBindGraphicsRootSig = true;
+        }
+
         // Apply the vars. Must be first because applyGraphicsVars() might cause a flush
         if (is_set(RenderContext::StateBindFlags::Vars, mBindFlags))
         {
             if (mpGraphicsVars)
             {
-                applyGraphicsVars();
+                applyGraphicsVars(pGraphicsKernels.get());
             }
         }
 
         if (is_set(RenderContext::StateBindFlags::PipelineState, mBindFlags))
         {
-            GraphicsStateObject::SharedPtr pGSO = mpGraphicsState->getGSO(mpGraphicsVars.get());
             vkCmdBindPipeline(mpLowLevelData->getCommandList(), VK_PIPELINE_BIND_POINT_GRAPHICS, pGSO->getApiHandle());
         }
         if (is_set(RenderContext::StateBindFlags::Fbo, mBindFlags))

--- a/Framework/Source/API/Vulkan/VKState.cpp
+++ b/Framework/Source/API/Vulkan/VKState.cpp
@@ -59,7 +59,7 @@ namespace Falcor
         }
     }
 
-    void initVkShaderStageInfo(const ProgramVersion* pProgram, std::vector<VkPipelineShaderStageCreateInfo>& infosOut)
+    void initVkShaderStageInfo(const ProgramKernels* pProgram, std::vector<VkPipelineShaderStageCreateInfo>& infosOut)
     {
         infosOut.clear();
 

--- a/Framework/Source/API/Vulkan/VKState.h
+++ b/Framework/Source/API/Vulkan/VKState.h
@@ -53,7 +53,7 @@ namespace Falcor
         VkRenderPassCreateInfo info;
     };
 
-    void initVkShaderStageInfo(const ProgramVersion* pProgram, std::vector<VkPipelineShaderStageCreateInfo>& infosOut);
+    void initVkShaderStageInfo(const ProgramKernels* pProgram, std::vector<VkPipelineShaderStageCreateInfo>& infosOut);
     void initVkBlendInfo(const Fbo::Desc& fboDesc, const BlendState* pState, ColorBlendStateCreateInfo& infoOut);
     void initVkRasterizerInfo(const RasterizerState* pState, VkPipelineRasterizationStateCreateInfo& infoOut);
     void initVkDepthStencilInfo(const DepthStencilState* pState, VkPipelineDepthStencilStateCreateInfo& infoOut);

--- a/Framework/Source/Graphics/ComputeState.cpp
+++ b/Framework/Source/Graphics/ComputeState.cpp
@@ -40,15 +40,15 @@ namespace Falcor
 
     ComputeStateObject::SharedPtr ComputeState::getCSO(const ComputeVars* pVars)
     {
-        ProgramVersion::SharedConstPtr pProgVersion = mpProgram ? mpProgram->getActiveVersion() : nullptr;
-        bool newProgram = (pProgVersion.get() != mCachedData.pProgramVersion);
+        ProgramKernels::SharedConstPtr pProgramKernels = mpProgram ? mpProgram->getActiveVersion()->getKernels(pVars) : nullptr;
+        bool newProgram = (pProgramKernels.get() != mCachedData.pProgramKernels);
         if (newProgram)
         {
-            mCachedData.pProgramVersion = pProgVersion.get();
-            mpCsoGraph->walk((void*)mCachedData.pProgramVersion);
+            mCachedData.pProgramKernels = pProgramKernels.get();
+            mpCsoGraph->walk((void*)mCachedData.pProgramKernels);
         }
 
-        RootSignature::SharedPtr pRoot = pVars ? pVars->getRootSignature() : RootSignature::getEmpty();
+        RootSignature::SharedPtr pRoot = pProgramKernels ? pProgramKernels->getRootSignature() : RootSignature::getEmpty();
 
         if (mCachedData.pRootSig != pRoot.get())
         {
@@ -60,7 +60,7 @@ namespace Falcor
 
         if(pCso == nullptr)
         {
-            mDesc.setProgramVersion(pProgVersion);
+            mDesc.setProgramKernels(pProgramKernels);
             mDesc.setRootSignature(pRoot);
 
             StateGraph::CompareFunc cmpFunc = [&desc = mDesc](ComputeStateObject::SharedPtr pCso) -> bool

--- a/Framework/Source/Graphics/ComputeState.h
+++ b/Framework/Source/Graphics/ComputeState.h
@@ -73,7 +73,7 @@ namespace Falcor
 
         struct CachedData
         {
-            const ProgramVersion* pProgramVersion = nullptr;
+            const ProgramKernels* pProgramKernels = nullptr;
             const RootSignature* pRootSig = nullptr;
         };
         CachedData mCachedData;

--- a/Framework/Source/Graphics/GraphicsState.cpp
+++ b/Framework/Source/Graphics/GraphicsState.cpp
@@ -74,15 +74,15 @@ namespace Falcor
         {
             mpVao->getVertexLayout()->addVertexAttribDclToProg(mpProgram.get());
         }
-        const ProgramVersion::SharedConstPtr pProgVersion = mpProgram ? mpProgram->getActiveVersion() : nullptr;
-        bool newProgVersion = pProgVersion.get() != mCachedData.pProgramVersion;
+        const ProgramKernels::SharedConstPtr pProgramKernels = mpProgram ? mpProgram->getActiveVersion()->getKernels(pVars) : nullptr;
+        bool newProgVersion = pProgramKernels.get() != mCachedData.pProgramKernels;
         if (newProgVersion)
         {
-            mCachedData.pProgramVersion = pProgVersion.get();
-            mpGsoGraph->walk((void*)pProgVersion.get());
+            mCachedData.pProgramKernels = pProgramKernels.get();
+            mpGsoGraph->walk((void*)pProgramKernels.get());
         }
     
-        RootSignature::SharedPtr pRoot = pVars ? pVars->getRootSignature() : RootSignature::getEmpty();
+        RootSignature::SharedPtr pRoot = pProgramKernels ? pProgramKernels->getRootSignature() : RootSignature::getEmpty();
 
         if (mCachedData.pRootSig != pRoot.get())
         {
@@ -100,7 +100,7 @@ namespace Falcor
         GraphicsStateObject::SharedPtr pGso = mpGsoGraph->getCurrentNode();
         if(pGso == nullptr)
         {
-            mDesc.setProgramVersion(pProgVersion);
+            mDesc.setProgramKernels(pProgramKernels);
             mDesc.setFboFormats(mpFbo ? mpFbo->getDesc() : Fbo::Desc());
 #ifdef FALCOR_VK
             mDesc.setRenderPass(mpFbo ? (VkRenderPass)mpFbo->getApiHandle() : VK_NULL_HANDLE);

--- a/Framework/Source/Graphics/GraphicsState.h
+++ b/Framework/Source/Graphics/GraphicsState.h
@@ -257,7 +257,7 @@ namespace Falcor
 
         struct CachedData
         {
-            const ProgramVersion* pProgramVersion = nullptr;
+            const ProgramKernels* pProgramKernels = nullptr;
             const RootSignature* pRootSig = nullptr;
             const Fbo::Desc* pFboDesc = nullptr;
         };

--- a/Framework/Source/Graphics/Program/ParameterBlock.h
+++ b/Framework/Source/Graphics/Program/ParameterBlock.h
@@ -40,7 +40,14 @@ namespace Falcor
     */
     class ParameterBlock : public std::enable_shared_from_this<ParameterBlock>
     {
+    private:
+        std::string mTypeName;
+        uint32_t mTypeId = 0;
     public:
+        void setTypeName(std::string name);
+        std::string getTypeName() const;
+        int getTypeId() const { return mTypeId; }
+
         template<typename T>
         class SharedPtrT : public std::shared_ptr<T>
         {

--- a/Framework/Source/Graphics/Program/ProgramReflection.cpp
+++ b/Framework/Source/Graphics/Program/ProgramReflection.cpp
@@ -442,7 +442,8 @@ namespace Falcor
 
     ReflectionType::SharedPtr reflectStructType(TypeLayoutReflection* pSlangType, const ReflectionPath* pPath)
     {
-        ReflectionStructType::SharedPtr pType = ReflectionStructType::create(getUniformOffset(pPath), pSlangType->getSize(), "");
+        auto name = pSlangType->getName();
+        ReflectionStructType::SharedPtr pType = ReflectionStructType::create(getUniformOffset(pPath), pSlangType->getSize(), name?name:"");
         for (uint32_t i = 0; i < pSlangType->getFieldCount(); i++)
         {
             ReflectionPath fieldPath;
@@ -471,11 +472,22 @@ namespace Falcor
         return pArrayType;
     }
 
+    ReflectionType::SharedPtr reflectGenericTypeParameterType(TypeLayoutReflection* pSlangType, const ReflectionPath* pPath)
+    {
+        ReflectionGenericType::SharedPtr result = ReflectionGenericType::create(pSlangType->getName());
+        return result;
+    }
+
     ReflectionType::SharedPtr reflectBasicType(TypeLayoutReflection* pSlangType, const ReflectionPath* pPath)
     {
         ReflectionBasicType::Type type = getVariableType(pSlangType->getScalarType(), pSlangType->getRowCount(), pSlangType->getColumnCount());
         ReflectionType::SharedPtr pType = ReflectionBasicType::create(getUniformOffset(pPath), type, false, pSlangType->getSize());
         return pType;
+    }
+
+    ReflectionType::SharedPtr reflectType(TypeLayoutReflection* pSlangType)
+    {
+        return reflectType(pSlangType, nullptr);
     }
 
     ReflectionType::SharedPtr reflectType(TypeLayoutReflection* pSlangType, const ReflectionPath* pPath)
@@ -494,6 +506,8 @@ namespace Falcor
             return reflectStructType(pSlangType, pPath);
         case TypeReflection::Kind::Array:
             return reflectArrayType(pSlangType, pPath);
+        case TypeReflection::Kind::GenericTypeParameter:
+            return reflectGenericTypeParameterType(pSlangType, pPath);
         default:
             return reflectBasicType(pSlangType, pPath);
         }
@@ -738,6 +752,14 @@ namespace Falcor
         if (!pSlangReflector) return;
 
         ParameterBlockReflection::SharedPtr pDefaultBlock = ParameterBlockReflection::create("");
+
+        // retrieve generic type argument index 
+        for (uint32_t i = 0; i < pSlangReflector->getTypeParameterCount(); i++)
+        {
+            auto typeParam = pSlangReflector->getTypeParameterByIndex(i);
+            this->typeParameterIndexMap[typeParam->getName()] = typeParam->getIndex();
+        }
+
         for (uint32_t i = 0; i < pSlangReflector->getParameterCount(); i++)
         {
             VariableLayoutReflection* pSlangLayout = pSlangReflector->getParameterByIndex(i);
@@ -756,6 +778,8 @@ namespace Falcor
                 ParameterBlockReflection::SharedPtr pBlock = ParameterBlockReflection::create(name);
                 pBlock->addResource(pVar);
                 pBlock->finalize();
+                auto paramBlockType = pVar->getType()->asResourceType();
+                pBlock->mType = paramBlockType->getStructType();
                 addParameterBlock(pBlock);
             }
             else
@@ -836,6 +860,14 @@ namespace Falcor
     ParameterBlockReflection::SharedPtr ParameterBlockReflection::create(const std::string& name)
     {
         return SharedPtr(new ParameterBlockReflection(name));
+    }
+
+    ParameterBlockReflection::SharedPtr ParameterBlockReflection::create(const std::string& name, ReflectionType::SharedPtr const& elementType)
+    {
+        auto pBlockReflector = ParameterBlockReflection::create(name);
+        pBlockReflector->setElementType(elementType);
+        pBlockReflector->finalize();
+        return pBlockReflector;
     }
 
     ParameterBlockReflection::ParameterBlockReflection(const std::string& name) : mName(name)
@@ -976,6 +1008,7 @@ namespace Falcor
 
         // If this is a constant-buffer, it might contain resources. Extract them.
         const ReflectionType* pType = pResourceType->getStructType().get();
+        this->mType = pResourceType->getStructType();
         const ReflectionStructType* pStruct = (pType != nullptr) ? pType->asStructType() : nullptr;
         if (pStruct)
         {
@@ -988,6 +1021,26 @@ namespace Falcor
             }
             flattenResources(pStruct, mResources);
         }
+    }
+
+    void ParameterBlockReflection::setElementType(const ReflectionType::SharedConstPtr & pType)
+    {
+        mType = pType;
+
+        auto resType = ReflectionResourceType::create(ReflectionResourceType::Type::ConstantBuffer,
+            ReflectionResourceType::Dimensions::Buffer,
+            ReflectionResourceType::StructuredType::Default,
+            ReflectionResourceType::ReturnType::Unknown,
+            ReflectionResourceType::ShaderAccess::Read);
+        resType->setStructType(pType);
+
+        // Note: `ParameterBlock::getDefaultConstantBuffer` determines if something
+        // is the default constant buffer based on whether its name matches the name
+        // of the reflector used to create it. We thus insert a dummy constant buffer
+        // variable into our parameter block that has the same name as the reflector.
+        //
+        auto pVar = ReflectionVar::create(mName, resType, 0, 0, 0);
+        addResource(pVar);
     }
 
     void ParameterBlockReflection::finalize()
@@ -1241,6 +1294,11 @@ namespace Falcor
         return dynamic_cast<const ReflectionArrayType*>(this);
     }
 
+    const ReflectionGenericType * ReflectionType::asGenericType() const
+    {
+        return dynamic_cast<const ReflectionGenericType*>(this);
+    }
+
     const ReflectionType* ReflectionType::unwrapArray() const
     {
         const ReflectionType* pType = this;
@@ -1288,6 +1346,12 @@ namespace Falcor
                 extractOffsets(pType, offset + i * pArrayType->getArrayStride(), count, offsetMap);
                 --count;
             }
+            return;
+        }
+
+        const ReflectionGenericType* pGenericType = pType->asGenericType();
+        if (pGenericType)
+        {
             return;
         }
 
@@ -1355,6 +1419,18 @@ namespace Falcor
         const ReflectionArrayType* pOther = other.asArrayType();
         if (!pOther) return false;
         return (*this == *pOther);
+    }
+    
+    ReflectionGenericType::SharedPtr ReflectionGenericType::create(std::string inName)
+    {
+        return SharedPtr(new ReflectionGenericType(inName));
+    }
+
+    bool ReflectionGenericType::operator==(const ReflectionType& other) const
+    {
+        const ReflectionGenericType* pOther = other.asGenericType();
+        if (!pOther) return false;
+        return (name == pOther->name);
     }
 
     bool ReflectionResourceType::operator==(const ReflectionType& other) const
@@ -1450,6 +1526,14 @@ namespace Falcor
     const ProgramReflection::ShaderVariable* ProgramReflection::getPixelShaderOutput(const std::string& name) const
     {
         return getShaderAttribute(name, mPsOut, "getPixelShaderOutput()");
+    }
+
+    uint32_t ProgramReflection::getTypeParameterIndexByName(const std::string & name) const
+    {
+        auto iter = typeParameterIndexMap.find(name);
+        if (iter != typeParameterIndexMap.end())
+            return iter->second;
+        return (uint32_t)-1;
     }
 
     const ReflectionResourceType::OffsetDesc& ReflectionResourceType::getOffsetDesc(size_t offset) const

--- a/Framework/Source/Graphics/Program/ProgramVars.h
+++ b/Framework/Source/Graphics/Program/ProgramVars.h
@@ -221,18 +221,10 @@ namespace Falcor
         */
         ProgramReflection::SharedConstPtr getReflection() const { return mpReflector; }
 
-        /** Get the root signature object
-        */
-        RootSignature::SharedPtr getRootSignature() const { return mpRootSignature; }
-
         /** Get the number of parameter-blocks
         */
         uint32_t getParameterBlockCount() const { return (uint32_t)mParameterBlocks.size(); }
         
-        /** Get a list of indices translating a parameter-block's set index to the root-signature entry index
-        */
-        const std::vector<uint32_t>& getParameterBlockRootIndices(uint32_t blockIndex) const { return mParameterBlocks[blockIndex].rootIndex; }
-
         /** Get parameter-block by index. You can translate a name to an index using the ProgramReflection object
         */
         const ParameterBlock::SharedConstPtr getParameterBlock(uint32_t blockIndex) const;
@@ -260,18 +252,16 @@ namespace Falcor
         ConstantBuffer::SharedPtr getConstantBuffer(uint32_t) const = delete;
 
         template<bool forGraphics>
-        bool applyProgramVarsCommon(CopyContext* pContext, bool bindRootSig);
+        bool applyProgramVarsCommon(CopyContext* pContext, bool bindRootSig, const ProgramKernels* pKernels);
 
     protected:
-        ProgramVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig);
+        ProgramVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers);
         
-        RootSignature::SharedPtr mpRootSignature;
         ProgramReflection::SharedConstPtr mpReflector;
 
         struct BlockData
         {
             ParameterBlock::SharedPtr pBlock;
-            std::vector<uint32_t> rootIndex;        // Maps the block's set-index to the root-signature entry
             bool bind = true;
         };
         BlockData mDefaultBlock;
@@ -279,7 +269,7 @@ namespace Falcor
         ProgramVars::BlockData initParameterBlock(const ParameterBlockReflection::SharedConstPtr& pBlockReflection, bool createBuffers);
 
         template<bool forGraphics>
-        bool bindRootSetsCommon(CopyContext* pContext, bool bindRootSig);
+        bool bindRootSetsCommon(CopyContext* pContext, bool bindRootSig, const ProgramKernels* pKernels);
     };
 
     class GraphicsVars : public ProgramVars, public std::enable_shared_from_this<GraphicsVars>
@@ -293,11 +283,11 @@ namespace Falcor
             \param[in] createBuffers If true, will create the ConstantBuffer objects. Otherwise, the user will have to bind the CBs himself
             \param[in] pRootSignature A root-signature describing how to bind resources into the shader. If this parameter is nullptr, a root-signature object will be created from the program reflection object
         */
-        static SharedPtr create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers = true, const RootSignature::SharedPtr& pRootSig = nullptr);
-        virtual bool apply(RenderContext* pContext, bool bindRootSig);
+        static SharedPtr create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers = true);
+        virtual bool apply(RenderContext* pContext, bool bindRootSig, const ProgramKernels* pKernels);
     protected:
-        GraphicsVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig) :
-            ProgramVars(pReflector, createBuffers, pRootSig) {}
+        GraphicsVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers) :
+            ProgramVars(pReflector, createBuffers) {}
     };
 
     class ComputeVars : public ProgramVars, public std::enable_shared_from_this<ComputeVars>
@@ -311,10 +301,10 @@ namespace Falcor
             \param[in] createBuffers If true, will create the ConstantBuffer objects. Otherwise, the user will have to bind the CBs himself
             \param[in] pRootSignature A root-signature describing how to bind resources into the shader. If this parameter is nullptr, a root-signature object will be created from the program reflection object
         */
-        static SharedPtr create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers = true, const RootSignature::SharedPtr& pRootSig = nullptr);
-        virtual bool apply(ComputeContext* pContext, bool bindRootSig);
+        static SharedPtr create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers = true);
+        virtual bool apply(ComputeContext* pContext, bool bindRootSig, const ProgramKernels* pKernels);
     protected:
-        ComputeVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig) :
-            ProgramVars(pReflector, createBuffers, pRootSig) {}
+        ComputeVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers) :
+            ProgramVars(pReflector, createBuffers) {}
     };
 }

--- a/Framework/Source/Graphics/Program/ProgramVersion.cpp
+++ b/Framework/Source/Graphics/Program/ProgramVersion.cpp
@@ -26,28 +26,107 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***************************************************************************/
 #include "Framework.h"
+#include "Graphics/Program/Program.h"
 #include "Graphics/Program/ProgramVersion.h"
+#include "ProgramVars.h"
 
 namespace Falcor
 {
-    ProgramVersion::ProgramVersion(const ProgramReflection::SharedPtr& pReflector, const Shader::SharedPtr& pVS, const Shader::SharedPtr& pPS, const Shader::SharedPtr& pGS, const Shader::SharedPtr& pHS, const Shader::SharedPtr& pDS, const Shader::SharedPtr& pCS, const std::string& name) 
-        : mName(name), mpReflector(pReflector)
+    static bool compareRootSets(const DescriptorSet::Layout& a, const DescriptorSet::Layout& b)
     {
-        mpShaders[(uint32_t)ShaderType::Vertex] = pVS;
-        mpShaders[(uint32_t)ShaderType::Pixel] = pPS;
-        mpShaders[(uint32_t)ShaderType::Geometry] = pGS;
-        mpShaders[(uint32_t)ShaderType::Domain] = pDS;
-        mpShaders[(uint32_t)ShaderType::Hull] = pHS;
-        mpShaders[(uint32_t)ShaderType::Compute] = pCS;
+        if (a.getRangeCount() != b.getRangeCount()) return false;
+        if (a.getVisibility() != b.getVisibility()) return false;
+        for (uint32_t i = 0; i < a.getRangeCount(); i++)
+        {
+            const auto& rangeA = a.getRange(i);
+            const auto& rangeB = b.getRange(i);
+            if (rangeA.baseRegIndex != rangeB.baseRegIndex) return false;
+            if (rangeA.descCount != rangeB.descCount) return false;
+#ifdef FALCOR_D3D12
+            if (rangeA.regSpace != rangeB.regSpace) return false;
+#endif
+            if (rangeA.type != rangeB.type) return false;
+        }
+        return true;
     }
 
-    ProgramVersion::SharedPtr ProgramVersion::create(
+    static uint32_t findRootIndex(const DescriptorSet::Layout& blockSet, const RootSignature::SharedPtr& pRootSig)
+    {
+        for (uint32_t i = 0; i < pRootSig->getDescriptorSetCount(); i++)
+        {
+            const auto& rootSet = pRootSig->getDescriptorSet(i);
+            if (compareRootSets(rootSet, blockSet))
+            {
+#ifdef FALCOR_D3D12
+                return i;
+#else
+                return rootSet.getRange(0).regSpace;
+#endif
+            }
+        }
+        should_not_get_here();
+        return -1;
+    }
+
+
+
+    ProgramKernels::ProgramKernels(
         const ProgramReflection::SharedPtr& pReflector,
+        Shader::SharedPtr const*            ppShaders,
+        size_t                              shaderCount,
+        const RootSignature::SharedPtr& pRootSignature,
+        const std::string& name) 
+        : mName(name), mpReflector(pReflector)
+    {
+        for( size_t i = 0; i < shaderCount; ++i )
+        {
+            auto pShader = ppShaders[i];
+            mpShaders[(uint32_t)pShader->getType()] = pShader;
+        }
+        mpRootSignature = pRootSignature;
+
+        auto parameterBlockCount = pReflector->getParameterBlockCount();
+        for (uint32_t i = 0; i < parameterBlockCount; i++)
+        {
+            const auto& pBlockReflection = pReflector->getParameterBlock(i);
+            BlockData data;
+
+            // For each set, find the matching root-index. 
+            const auto& sets = pBlockReflection->getDescriptorSetLayouts();
+            data.rootIndex.resize(sets.size());
+            for (size_t i = 0; i < sets.size(); i++)
+            {
+                data.rootIndex[i] = findRootIndex(sets[i], mpRootSignature);
+            }
+
+            mParameterBlocks.push_back(data);
+        }
+    }
+
+    ProgramKernels::SharedPtr ProgramKernels::create(
+        const ProgramReflection::SharedPtr& pReflector,
+        Shader::SharedPtr const*            ppShaders,
+        size_t                              shaderCount,
+        const RootSignature::SharedPtr&     pRootSignature,
+        std::string&                        log,
+        const std::string&                  name)
+    {
+        SharedPtr pProgram = SharedPtr(new ProgramKernels(pReflector, ppShaders, shaderCount, pRootSignature, name));
+        if (pProgram->init(log) == false)
+        {
+            return nullptr;
+        }
+        return pProgram;
+    }
+
+    ProgramKernels::SharedPtr ProgramKernels::create(
+        ProgramReflection::SharedPtr const& pReflector,
         const Shader::SharedPtr& pVS,
         const Shader::SharedPtr& pPS,
         const Shader::SharedPtr& pGS,
         const Shader::SharedPtr& pHS,
         const Shader::SharedPtr& pDS,
+        const RootSignature::SharedPtr& pRootSignature,
         std::string& log,
         const std::string& name)
     {
@@ -57,7 +136,18 @@ namespace Falcor
             log = "Program " + name + " doesn't contain a vertex-shader. This is illegal.";
             return nullptr;
         }
-        SharedPtr pProgram = SharedPtr(new ProgramVersion(pReflector, pVS, pPS, pGS, pHS, pDS, nullptr, name));
+
+        static const size_t kMaxShaderCount = 5;
+        Shader::SharedPtr shaders[kMaxShaderCount];
+        size_t shaderCount = 0;
+
+        if(pVS) shaders[shaderCount++] = pVS;
+        if(pPS) shaders[shaderCount++] = pPS;
+        if(pGS) shaders[shaderCount++] = pGS;
+        if(pHS) shaders[shaderCount++] = pHS;
+        if(pDS) shaders[shaderCount++] = pDS;
+
+        SharedPtr pProgram = SharedPtr(new ProgramKernels(pReflector, shaders, shaderCount, pRootSignature, name));
 
         if(pProgram->init(log) == false)
         {
@@ -67,9 +157,10 @@ namespace Falcor
         return pProgram;
     }
 
-    ProgramVersion::SharedPtr ProgramVersion::create(
+    ProgramKernels::SharedPtr ProgramKernels::create(
         const ProgramReflection::SharedPtr& pReflector,
         const Shader::SharedPtr& pCS,
+        const RootSignature::SharedPtr& pRootSignature,
         std::string& log,
         const std::string& name)
     {
@@ -79,7 +170,7 @@ namespace Falcor
             log = "Program " + name + " doesn't contain a compute-shader. This is illegal.";
             return nullptr;
         }
-        SharedPtr pProgram = SharedPtr(new ProgramVersion(pReflector, nullptr, nullptr, nullptr, nullptr, nullptr, pCS, name));
+        SharedPtr pProgram = SharedPtr(new ProgramKernels(pReflector, &pCS, 1, pRootSignature, name));
 
         if (pProgram->init(log) == false)
         {
@@ -88,8 +179,140 @@ namespace Falcor
         return pProgram;
     }
 
-    ProgramVersion::~ProgramVersion()
+    ProgramKernels::~ProgramKernels()
     {
         deleteApiHandle();
     }
+
+    ProgramVersion::SharedPtr ProgramVersion::create(
+        std::shared_ptr<Program>     const& pProgram,
+        DefineList                   const& defines,
+        ProgramReflectors            const& reflectors,
+        std::string                  const& name,
+        SlangCompileRequest*                pSlangRequest)
+    {
+        return SharedPtr(new ProgramVersion(pProgram, defines, reflectors, name, pSlangRequest));
+    }
+
+    ProgramVersion::ProgramVersion(
+        std::shared_ptr<Program>     const& pProgram,
+        DefineList                   const& defines,
+        ProgramReflectors            const& reflectors,
+        std::string                  const& name,
+        SlangCompileRequest*                pSlangRequest)
+        : mpProgram(pProgram)
+        , mDefines(defines)
+        , mReflectors(reflectors)
+        , mName(name)
+        , mpSlangRequest(pSlangRequest)
+    {
+        mpKernelGraph = KernelGraph::create();
+    }
+
+    ProgramVersion::~ProgramVersion()
+    {
+        spDestroyCompileRequest(mpSlangRequest);
+    }
+
+    ProgramKernels::SharedConstPtr ProgramVersion::getKernels(ProgramVars const* pVars) const
+    {
+        // The compiled kernels will depend on the types of the parameter blocks
+        // bound in `pVars`. We will walk a `Graph` to look up the right kernels
+        // to use.
+        //
+        auto parameterBlockCount = pVars->getParameterBlockCount();
+        for(uint32_t i = 0; i < parameterBlockCount; ++i)
+        {
+            auto blockTypeID = pVars->getParameterBlock(i)->getTypeId();
+            mpKernelGraph->walk(blockTypeID);
+        }
+
+        // If we already have cached data at the chosen graph node, then use it.
+        //
+        auto entry = mpKernelGraph->getCurrentNode();
+        if(entry.pKernels)
+            return entry.pKernels;
+
+        // Otherwise, we will construct the list of all the parameter block type IDs,
+        // and use that as a key when searching for a matching graph node.
+        //
+        for(uint32_t i = 0; i < parameterBlockCount; ++i)
+        {
+            auto blockTypeID = pVars->getParameterBlock(i)->getTypeId();
+            entry.parameterBlockTypes.push_back(blockTypeID);
+        }
+
+        KernelGraph::CompareFunc cmpFunc = [&](KernelGraphEntry const& other)
+        {
+            if(parameterBlockCount != other.parameterBlockTypes.size()) return false;
+            for(uint32_t i = 0; i < parameterBlockCount; ++i)
+            {
+                if(entry.parameterBlockTypes[i] != other.parameterBlockTypes[i]) return false;
+            }
+            return true;
+        };
+
+        if(mpKernelGraph->scanForMatchingNode(cmpFunc))
+        {
+            entry = mpKernelGraph->getCurrentNode();
+        }
+        else
+        {
+            entry.pKernels = createKernels(pVars);
+            mpKernelGraph->setCurrentNodeData(entry);
+        }
+
+        return entry.pKernels;
+    }
+
+    ProgramKernels::SharedConstPtr ProgramVersion::createKernels(ProgramVars const* pVars) const
+    {
+        // Loop so that user can trigger recompilation on error
+        for(;;)
+        {
+            std::string log;
+            auto pKernels = mpProgram->preprocessAndCreateProgramKernels(this, pVars, log);
+            if( pKernels )
+            {
+                // Success.
+                return pKernels;
+            }
+            else
+            {
+                // Failure
+                std::string error = std::string("Program Linkage failed.\n\n");
+                error += getName() + "\n";
+                error += log;
+                 
+                if(msgBox(error, MsgBoxType::RetryCancel) == MsgBoxButton::Cancel)
+                {
+                    // User has chosen not to retry
+                    logError(error);
+                    return nullptr;
+                }
+
+                // Continue loop to keep trying...
+            }
+        }
+    }
+
+    ParameterBlockReflection::SharedConstPtr ProgramVersion::getParameterBlockReflectorForType(std::string const& name) const
+    {
+        auto ii = mParameterBlockTypes.find(name);
+        if( ii != mParameterBlockTypes.end() )
+        {
+            return ii->second;
+        }
+
+        auto pSlangReflector = slang::ShaderReflection::get(mpSlangRequest);
+        auto pSlangType = pSlangReflector->findTypeByName(name.c_str());
+        auto pSlangTypeLayout = pSlangReflector->getTypeLayout(pSlangType);
+
+        auto pTypeReflector = reflectType(pSlangTypeLayout);
+
+        ParameterBlockReflection::SharedPtr pBlockReflector = ParameterBlockReflection::create(name, pTypeReflector);
+        mParameterBlockTypes.insert(std::make_pair(name, pBlockReflector));
+        return pBlockReflector;
+    }
+
 }

--- a/Framework/Source/Graphics/Program/ProgramVersion.h
+++ b/Framework/Source/Graphics/Program/ProgramVersion.h
@@ -31,23 +31,42 @@
 #include <map>
 #include <vector>
 #include "API/Shader.h"
-#include "Graphics/Program//ProgramReflection.h"
+#include "Graphics/Program/ProgramReflection.h"
+#include "API/LowLevel/RootSignature.h"
+#include "Utils/Graph.h"
 
 namespace Falcor
 {
     class ConstantBuffer;
+    class Program;
+    class ProgramVars;
 
     /** Low-level program object
         This class abstracts the API's program creation and management
     */
-    class ProgramVersion : public std::enable_shared_from_this<ProgramVersion>
+    class ProgramKernels : public std::enable_shared_from_this<ProgramKernels>
     {
     public:
-        using SharedPtr = std::shared_ptr<ProgramVersion>;
-        using SharedConstPtr = std::shared_ptr<const ProgramVersion>;
+        using SharedPtr = std::shared_ptr<ProgramKernels>;
+        using SharedConstPtr = std::shared_ptr<const ProgramKernels>;
+
+        /** Create a new program object.
+            \param[in]  ppShaders Zero or mroe shaders to go into the program
+            \param[in]  shaderCount The number of shaders in ppShaders
+            \param[in]  pRootSignature The root signature of the compiled kernels.
+            \param[out] log In case of error, this will contain the error log string
+            \param[in]  name Optional. A meaningful name to use with log messages
+            \return New object in case of success, otherwise nullptr
+        */
+        static SharedPtr create(
+            const ProgramReflection::SharedPtr& pReflector,
+            Shader::SharedPtr const*            ppShaders,
+            size_t                              shaderCount,
+            const RootSignature::SharedPtr&     pRootSignature,
+            std::string&                        log, 
+            const std::string&                  name = "");
 
         /** Create a new program object for graphics.
-            \param[in] The program reflection object
             \param[in] pVS Vertex shader object
             \param[in] pPS Fragment shader object
             \param[in] pGS Geometry shader object
@@ -64,11 +83,11 @@ namespace Falcor
             const Shader::SharedPtr& pGS,
             const Shader::SharedPtr& pHS,
             const Shader::SharedPtr& pDS,
+            const RootSignature::SharedPtr& pRootSignature,
             std::string& log, 
             const std::string& name = "");
 
         /** Create a new program object for compute.
-            \param[in] The program reflection object
             \param[in] pCs Compute shader object
             \param[out] Log In case of error, this will contain the error log string
             \param[in] DebugName Optional. A meaningful name to use with log messages
@@ -77,10 +96,11 @@ namespace Falcor
         static SharedPtr create(
             const ProgramReflection::SharedPtr& pReflector,
             const Shader::SharedPtr& pCS,
+            const RootSignature::SharedPtr& pRootSignature,
             std::string& log,
             const std::string& name = "");
 
-        virtual ~ProgramVersion();
+        virtual ~ProgramKernels();
 
         /** Get an attached shader object, or nullptr if no shader is attached to the slot.
         */
@@ -92,16 +112,24 @@ namespace Falcor
 
         /** Get the reflection object
         */
-        const ProgramReflection::SharedPtr& getReflector() const { return mpReflector; }
+
+        ProgramReflection::SharedConstPtr getReflector() const { return mpReflector; }
+        
+        /** Get the root signature object associated with this ProgramKernel
+        */
+        RootSignature::SharedPtr const& getRootSignature() const { return mpRootSignature; }
+
+        /** Get a list of indices translating a parameter-block's set index to the root-signature entry index
+        */
+        const std::vector<uint32_t>& getParameterBlockRootIndices(uint32_t blockIndex) const { return mParameterBlocks[blockIndex].rootIndex; }
+
     protected:
-        ProgramVersion(const ProgramReflection::SharedPtr& pReflector,
-            const Shader::SharedPtr& pVS,
-            const Shader::SharedPtr& pPS,
-            const Shader::SharedPtr& pGS,
-            const Shader::SharedPtr& pHS,
-            const Shader::SharedPtr& pDS,
-            const Shader::SharedPtr& pCS,
-            const std::string& name = "");
+        ProgramKernels(
+            const ProgramReflection::SharedPtr& pReflector, 
+            Shader::SharedPtr const*            ppShaders,
+            size_t                              shaderCount,
+            const RootSignature::SharedPtr&     pRootSignature,
+            const std::string&                  name = "");
 
         virtual bool init(std::string& log);
         void deleteApiHandle();
@@ -112,6 +140,92 @@ namespace Falcor
         Shader::SharedConstPtr mpShaders[kShaderCount];
 
         void* mpPrivateData;
-        const ProgramReflection::SharedPtr mpReflector;
+        ProgramReflection::SharedConstPtr mpReflector;
+        RootSignature::SharedPtr mpRootSignature;
+
+        struct BlockData
+        {
+            std::vector<uint32_t> rootIndex;        // Maps the block's set-index to the root-signature entry
+        };
+        std::vector<BlockData> mParameterBlocks; 
+    };
+
+    /** A `Program` specialized to particular `#define`s
+    */
+    class ProgramVersion : public std::enable_shared_from_this<ProgramVersion>
+    {
+    public:
+        using SharedPtr = std::shared_ptr<ProgramVersion>;
+        using SharedConstPtr = std::shared_ptr<const ProgramVersion>;
+        using DefineList = Shader::DefineList;
+
+        static SharedPtr create(
+            std::shared_ptr<Program>     const& pProgram,
+            DefineList                   const& defines,
+            ProgramReflectors            const& reflectors,
+            std::string                  const& name,
+            SlangCompileRequest*                pSlangRequest);
+
+        ~ProgramVersion();
+
+        /** Get the program that this version was created from
+        */
+        std::shared_ptr<Program> getProgram() const { return mpProgram; }
+
+        /** Get the defines that were used to create this version
+        */
+        DefineList const& getDefines() const { return mDefines; }
+
+        /** Get the program name
+        */
+        const std::string& getName() const {return mName;}
+
+        /** Get the reflection object
+        */
+        ProgramReflection::SharedPtr getReflector() const { return mReflectors.pReflector; }
+
+        ProgramReflection::SharedPtr getLocalReflector() const { return mReflectors.pLocalReflector; }
+        ProgramReflection::SharedPtr getGlobalReflector() const { return mReflectors.pGlobalReflector; }
+
+        /** Get executable kernels based on state in a `ProgramVars`
+        */
+        ProgramKernels::SharedConstPtr getKernels(ProgramVars const* pVars) const;
+
+        ParameterBlockReflection::SharedConstPtr getParameterBlockReflectorForType(std::string const& name) const;
+
+    protected:
+        ProgramVersion(
+            std::shared_ptr<Program>     const& pProgram,
+            DefineList                   const& defines,
+            ProgramReflectors            const& reflectors,
+            std::string                  const& name,
+            SlangCompileRequest*                pSlangRequest);
+
+        ProgramKernels::SharedConstPtr createKernels(ProgramVars const* pVars) const;
+
+        std::shared_ptr<Program>        mpProgram;
+        DefineList                      mDefines;
+        ProgramReflectors               mReflectors;
+        std::string                     mName;
+
+        // The Slang compile request that created this version.
+        //
+        // Used to look up types and layouts when parameter blocks get created.
+        SlangCompileRequest* mpSlangRequest = nullptr;
+
+        // A cache of parameter block reflection objects based on Slang
+        // type that have been looked up on-demand.
+        //
+        typedef std::map<std::string, ParameterBlockReflection::SharedConstPtr> ParameterBlockTypes;
+        mutable ParameterBlockTypes mParameterBlockTypes;
+
+        // Cached version of compiled kernels for this program version
+        struct KernelGraphEntry
+        {
+            ProgramKernels::SharedConstPtr  pKernels;
+            std::vector<uint32_t>           parameterBlockTypes;
+        };
+        using KernelGraph = Graph<KernelGraphEntry, uint32_t>;
+        KernelGraph::SharedPtr mpKernelGraph;
     };
 }

--- a/Framework/Source/Raytracing/DXR.h
+++ b/Framework/Source/Raytracing/DXR.h
@@ -68,5 +68,5 @@ namespace Falcor
     class RenderContext;
     class RtProgramVars;
     class RtState;
-
+    class RtStateObject;
 }

--- a/Framework/Source/Raytracing/RtProgram/HitProgram.cpp
+++ b/Framework/Source/Raytracing/RtProgram/HitProgram.cpp
@@ -72,7 +72,7 @@ namespace Falcor
         OK = OK && (_pshader != nullptr);                       \
     }
 
-    ProgramVersion::SharedPtr HitProgram::createProgramVersion(std::string& log, const Shader::Blob shaderBlob[kShaderCount], const ProgramReflectors& reflectors) const
+    ProgramKernels::SharedPtr HitProgram::createProgramKernels(std::string& log, const Shader::Blob shaderBlob[kShaderCount], const ProgramReflectors& reflectors) const
     {
         RtShader::SharedPtr pAnyHit, pIntersect, pClosestHit;
         bool OK = true;
@@ -80,7 +80,6 @@ namespace Falcor
         create_shader(ShaderType::Intersection, pIntersect);
         create_shader(ShaderType::AnyHit, pAnyHit);
         create_shader(ShaderType::ClosestHit, pClosestHit);
-
-        return OK ? RtProgramVersion::createHit(pAnyHit, pClosestHit, pIntersect, log, getProgramDescString(), reflectors.pLocalReflector, mMaxPayloadSize, mMaxAttributeSize) : nullptr;
+        return OK ? RtProgramKernels::createHit(pAnyHit, pClosestHit, pIntersect, log, getProgramDescString(), reflectors.pLocalReflector, mMaxPayloadSize, mMaxAttributeSize) : nullptr;
     }
 }

--- a/Framework/Source/Raytracing/RtProgram/HitProgram.h
+++ b/Framework/Source/Raytracing/RtProgram/HitProgram.h
@@ -46,15 +46,12 @@ namespace Falcor
             uint32_t maxPayloadSize = FALCOR_RT_MAX_PAYLOAD_SIZE_IN_BYTES,
             uint32_t maxAttributeSize = D3D12_RAYTRACING_MAX_ATTRIBUTE_SIZE_IN_BYTES 
             );
-
-        RtProgramVersion::SharedConstPtr getActiveVersion() const { return std::dynamic_pointer_cast<const RtProgramVersion>(Program::getActiveVersion()); }
-
     private:
         HitProgram(uint32_t maxPayloadSize, uint32_t maxAttributeSize) : mMaxPayloadSize(maxPayloadSize), mMaxAttributeSize(maxAttributeSize) {}
         uint32_t mMaxPayloadSize;
         uint32_t mMaxAttributeSize;
 
         static HitProgram::SharedPtr createCommon(const std::string& filename, const std::string& closestHitEntry, const std::string& anyHitEntry, const std::string& intersectionEntry, const DefineList& programDefines, bool fromFile, uint32_t maxPayloadSize, uint32_t maxAttributeSize);
-        virtual ProgramVersion::SharedPtr createProgramVersion(std::string& log, const Shader::Blob shaderBlob[kShaderCount], const ProgramReflectors& reflectors) const override;
+        virtual ProgramKernels::SharedPtr createProgramKernels(std::string& log, const Shader::Blob shaderBlob[kShaderCount], const ProgramReflectors& reflectors) const override;
     };
 }

--- a/Framework/Source/Raytracing/RtProgram/RtProgramVersion.cpp
+++ b/Framework/Source/Raytracing/RtProgram/RtProgramVersion.cpp
@@ -33,14 +33,15 @@
 
 namespace Falcor
 {
-    uint64_t RtProgramVersion::sProgId = 0;
+    uint64_t RtProgramKernels::sProgId = 0;
     ProgramReflection::SharedPtr createProgramReflection(const Shader::SharedConstPtr pShaders[], std::string& log);
 
-    RtProgramVersion::RtProgramVersion(std::shared_ptr<ProgramReflection> pReflector, Type progType, RtShader::SharedPtr const* ppShaders, size_t shaderCount, const std::string& name, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
-        : ProgramVersion(pReflector, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, name)
+    RtProgramKernels::RtProgramKernels(std::shared_ptr<ProgramReflection> pReflector, Type progType, Shader::SharedPtr const* ppShaders, size_t shaderCount,  const std::string& name, uint32_t maxPayloadSize, uint32_t maxAttributeSize, std::string const& exportName)
+        : ProgramKernels(pReflector, ppShaders, shaderCount, RootSignature::create(pReflector.get(), true), name)
         , mType(progType)
         , mMaxAttributeSize(maxAttributeSize)
         , mMaxPayloadSize(maxPayloadSize)
+        , mExportName(string_2_wstring(exportName))
     {
         for( size_t ii = 0; ii < shaderCount; ++ii )
         {
@@ -48,23 +49,25 @@ namespace Falcor
             mpShaders[uint32_t(pShader->getType())] = pShader;
         }
 
+#if 0
         switch (mType)
         {
-        case Falcor::RtProgramVersion::Type::RayGeneration:
+        case Falcor::RtProgramKernels::Type::RayGeneration:
             mExportName = string_2_wstring(ppShaders[0]->getEntryPoint());
             break;
-        case Falcor::RtProgramVersion::Type::Hit:
+        case Falcor::RtProgramKernels::Type::Hit:
             mExportName = L"RtProgramVersion" + std::to_wstring(sProgId++);
             break;
-        case Falcor::RtProgramVersion::Type::Miss:
+        case Falcor::RtProgramKernels::Type::Miss:
             mExportName = string_2_wstring(ppShaders[0]->getEntryPoint());
             break;
         default:
             should_not_get_here();
         }
+#endif
     }
 
-    bool RtProgramVersion::initCommon(std::string& log)
+    bool RtProgramKernels::initCommon(std::string& log)
     {
         if (init(log) == false)
         {
@@ -72,26 +75,26 @@ namespace Falcor
         }
 
         // Create the root signature
-        mpLocalRootSignature = RootSignature::create(mpReflector.get(), true);
+//        mpLocalRootSignature = RootSignature::create(mpReflector.get(), true);
         return true;
     }
 
-    RtProgramVersion::Type getProgTypeFromShader(ShaderType shaderType)
+    RtProgramKernels::Type getProgTypeFromShader(ShaderType shaderType)
     {
         switch (shaderType)
         {
         case ShaderType::Miss:
-            return RtProgramVersion::Type::Miss;
+            return RtProgramKernels::Type::Miss;
         case ShaderType::RayGeneration:
-            return RtProgramVersion::Type::RayGeneration;
+            return RtProgramKernels::Type::RayGeneration;
         default:
             should_not_get_here();
-            return RtProgramVersion::Type(-1);
+            return RtProgramKernels::Type(-1);
         }
     }
     
     template<ShaderType shaderType>
-    RtProgramVersion::SharedPtr RtProgramVersion::createSingleShaderProgram(RtShader::SharedPtr pShader, std::string& log, const std::string& name, ProgramReflection::SharedPtr pLocalReflector, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
+    RtProgramKernels::SharedPtr RtProgramKernels::createSingleShaderProgram(RtShader::SharedPtr pShader, std::string& log, const std::string& name, ProgramReflection::SharedPtr pLocalReflector, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
     {
         // We are using the RayGeneration structure in the union to avoid code duplication, these asserts make sure that our assumptions are correct
 
@@ -101,7 +104,10 @@ namespace Falcor
             return nullptr;
         }
 
-        SharedPtr pProgram = SharedPtr(new RtProgramVersion(pLocalReflector, getProgTypeFromShader(shaderType), &pShader, 1, name, maxPayloadSize, maxAttributeSize));
+        Shader::SharedPtr ppShaders[] = { pShader };
+
+        auto exportName = pShader->getEntryPoint();
+        SharedPtr pProgram = SharedPtr(new RtProgramKernels(pLocalReflector, getProgTypeFromShader(shaderType), ppShaders, 1, name, maxPayloadSize, maxAttributeSize, exportName));
         if (pProgram->initCommon(log) == false)
         {
             return nullptr;
@@ -110,7 +116,7 @@ namespace Falcor
         return pProgram;
     }
 
-    RtShader::SharedConstPtr RtProgramVersion::getShader(ShaderType type) const
+    RtShader::SharedConstPtr RtProgramKernels::getShader(ShaderType type) const
     {
         Shader::SharedConstPtr pShader = mpShaders[(uint32_t)type];
         RtShader::SharedConstPtr pRtShader = std::dynamic_pointer_cast<const RtShader>(pShader);
@@ -118,20 +124,20 @@ namespace Falcor
         return pRtShader;
     }
 
-    RtProgramVersion::SharedPtr RtProgramVersion::createRayGen(RtShader::SharedPtr pRayGenShader, std::string& log, const std::string& name, ProgramReflection::SharedPtr pLocalReflector, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
+    RtProgramKernels::SharedPtr RtProgramKernels::createRayGen(RtShader::SharedPtr pRayGenShader, std::string& log, const std::string& name, ProgramReflection::SharedPtr pLocalReflector, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
     {
         return createSingleShaderProgram<ShaderType::RayGeneration>(pRayGenShader, log, name, pLocalReflector, maxPayloadSize, maxAttributeSize);
     }
 
-    RtProgramVersion::SharedPtr RtProgramVersion::createMiss(RtShader::SharedPtr pMissShader, std::string& log, const std::string& name, ProgramReflection::SharedPtr pLocalReflector, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
+    RtProgramKernels::SharedPtr RtProgramKernels::createMiss(RtShader::SharedPtr pMissShader, std::string& log, const std::string& name, ProgramReflection::SharedPtr pLocalReflector, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
     {
         return createSingleShaderProgram<ShaderType::Miss>(pMissShader, log, name, pLocalReflector, maxPayloadSize, maxAttributeSize);
     }
     
-    RtProgramVersion::SharedPtr RtProgramVersion::createHit(RtShader::SharedPtr pAnyHit, RtShader::SharedPtr pClosestHit, RtShader::SharedPtr pIntersection, std::string& log, const std::string& name, ProgramReflection::SharedPtr pReflector, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
+    RtProgramKernels::SharedPtr RtProgramKernels::createHit(RtShader::SharedPtr pAnyHit, RtShader::SharedPtr pClosestHit, RtShader::SharedPtr pIntersection, std::string& log, const std::string& name, ProgramReflection::SharedPtr pReflector, uint32_t maxPayloadSize, uint32_t maxAttributeSize)
     {
         size_t shaderCount = 0;
-        RtShader::SharedPtr pShaders[3];
+        Shader::SharedPtr pShaders[3];
 
         if(pAnyHit)         pShaders[shaderCount++] = pAnyHit;
         if(pClosestHit)     pShaders[shaderCount++] = pClosestHit;
@@ -143,12 +149,123 @@ namespace Falcor
             return nullptr;
         }
 
-        SharedPtr pProgram = SharedPtr(new RtProgramVersion(pReflector, Type::Hit, pShaders, shaderCount, name, maxPayloadSize, maxAttributeSize));
+        auto exportName = "RtHitGroup" + std::to_string(sProgId++);
+        SharedPtr pProgram = SharedPtr(new RtProgramKernels(pReflector, Type::Hit, pShaders, shaderCount, name, maxPayloadSize, maxAttributeSize, exportName));
         if (pProgram->initCommon(log) == false)
         {
             return nullptr;
         }
 
         return pProgram;
+    }
+
+    RtPipelineKernels::SharedPtr RtPipelineKernels::create(
+        ProgramKernels::SharedConstPtr const& pGlobalProgram,
+        RtProgramKernels::SharedConstPtr const& pRayGenProgram,
+        std::vector<RtProgramKernels::SharedConstPtr> const& hitPrograms,
+        std::vector<RtProgramKernels::SharedConstPtr> const& missPrograms)
+    {
+        auto pKernels = SharedPtr(new RtPipelineKernels(pGlobalProgram, pRayGenProgram, hitPrograms, missPrograms));
+        pKernels->init();
+        return pKernels;
+    }
+
+    RtPipelineKernels::RtPipelineKernels(
+        ProgramKernels::SharedConstPtr const& pGlobalProgram,
+        RtProgramKernels::SharedConstPtr const& pRayGenProgram,
+        std::vector<RtProgramKernels::SharedConstPtr> const& hitPrograms,
+        std::vector<RtProgramKernels::SharedConstPtr> const& missPrograms)
+        : mpGlobalProgram(pGlobalProgram)
+        , mRecordSize(0)
+        , mpRayGenProgram(pRayGenProgram)
+        , mHitPrograms(hitPrograms)
+        , mMissPrograms(missPrograms)
+    {}
+
+    void RtPipelineKernels::init()
+    {
+        uint32_t maxRootSigSize = 0;
+
+        auto addProgramAndComputeMaxSize = [&](RtProgramKernels::SharedConstPtr const& pProgram)
+        {
+            mProgramList.push_back(pProgram);
+            maxRootSigSize = std::max(maxRootSigSize, pProgram->getLocalRootSignature()->getSizeInBytes());
+        };
+
+        addProgramAndComputeMaxSize(mpRayGenProgram);
+
+        for( auto pHitProgram : mHitPrograms )
+        {
+            addProgramAndComputeMaxSize(pHitProgram);
+        }
+        for( auto pMissProgram : mMissPrograms )
+        {
+            addProgramAndComputeMaxSize(pMissProgram);
+        }
+
+        // Get the program identifier size
+        ID3D12DeviceRaytracingPrototypePtr pRtDevice = gpDevice->getApiHandle();
+        uint32_t programIdentifierSize = pRtDevice->GetShaderIdentifierSize();
+
+        // Calculate the record size
+        uint32_t recordSize = programIdentifierSize + maxRootSigSize;
+        recordSize = align_to(D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT, recordSize);
+        assert(recordSize != 0);
+
+        mRecordSize = recordSize;
+    }
+
+    RtPipelineVersion::SharedPtr RtPipelineVersion::create(
+        std::shared_ptr<ProgramReflection> pGlobalReflector,
+        ProgramVersion::SharedConstPtr pRayGenProgram,
+        std::vector<ProgramVersion::SharedConstPtr> hitPrograms,
+        std::vector<ProgramVersion::SharedConstPtr> missPrograms)
+    {
+        auto result = SharedPtr(new RtPipelineVersion(
+            pGlobalReflector,
+            pRayGenProgram,
+            hitPrograms,
+            missPrograms));
+
+        if( !result->init() )
+        {
+            return nullptr;
+        }
+        return result;
+    }
+
+    RtPipelineVersion::RtPipelineVersion(
+        std::shared_ptr<ProgramReflection> pGlobalReflector,
+        ProgramVersion::SharedConstPtr pRayGenProgram,
+        std::vector<ProgramVersion::SharedConstPtr> hitPrograms,
+        std::vector<ProgramVersion::SharedConstPtr> missPrograms)
+        : mpGlobalReflector(pGlobalReflector)
+        , mpRayGenProgram(pRayGenProgram)
+        , mHitPrograms(hitPrograms)
+        , mMissPrograms(missPrograms)
+    {}
+
+    bool RtPipelineVersion::init()
+    {
+        std::string log;
+        auto pGlobalReflector = mpGlobalReflector;
+        auto pGlobalRootSignature = RootSignature::create(pGlobalReflector.get());
+        if(!pGlobalRootSignature)
+            return false;
+
+        auto pGlobalKernels = ProgramKernels::create(
+            pGlobalReflector,
+            nullptr,
+            0,
+            pGlobalRootSignature,
+            log,
+            "ray tracing global parameters");
+        if(!pGlobalKernels)
+            return false;
+
+        mpGlobalKernels = pGlobalKernels;
+        mpKernelGraph = KernelGraph::create();
+
+        return true;
     }
 }

--- a/Framework/Source/Raytracing/RtProgram/SingleShaderProgram.h
+++ b/Framework/Source/Raytracing/RtProgram/SingleShaderProgram.h
@@ -46,8 +46,6 @@ namespace Falcor
             return createCommon(filename, entryPoint, programDefines, maxPayloadSize, maxAttributesSize);
         }
 
-        RtProgramVersion::SharedConstPtr getActiveVersion() const { return std::dynamic_pointer_cast<const RtProgramVersion>(Program::getActiveVersion()); }
-
     private:
         RtSingleShaderProgram(uint32_t maxPayloadSize, uint32_t maxAttributesSize) : mMaxPayloadSize(maxPayloadSize), mMaxAttributesSize(maxAttributesSize) {}
 
@@ -64,7 +62,7 @@ namespace Falcor
             return pProg;
         }
 
-        virtual ProgramVersion::SharedPtr createProgramVersion(std::string& log, const Shader::Blob shaderBlob[kShaderCount], const ProgramReflectors& reflectors) const override
+        virtual ProgramKernels::SharedPtr createProgramKernels(std::string& log, const Shader::Blob shaderBlob[kShaderCount], const ProgramReflectors& reflectors) const override
         {
             RtShader::SharedPtr pShader;
             pShader = createRtShaderFromBlob(mDesc.getShaderLibrary(ShaderType(shaderType))->getFilename(), mDesc.getShaderEntryPoint(ShaderType(shaderType)), shaderBlob[uint32_t(shaderType)], mDesc.getCompilerFlags(), shaderType, log);
@@ -74,9 +72,9 @@ namespace Falcor
                 switch (shaderType)
                 {
                 case ShaderType::RayGeneration:
-                    return RtProgramVersion::createRayGen(pShader, log, getProgramDescString(), reflectors.pLocalReflector, mMaxPayloadSize, mMaxAttributesSize);
+                    return RtProgramKernels::createRayGen(pShader, log, getProgramDescString(), reflectors.pLocalReflector, mMaxPayloadSize, mMaxAttributesSize);
                 case ShaderType::Miss:
-                    return RtProgramVersion::createMiss(pShader, log, getProgramDescString(), reflectors.pLocalReflector, mMaxPayloadSize, mMaxAttributesSize);
+                    return RtProgramKernels::createMiss(pShader, log, getProgramDescString(), reflectors.pLocalReflector, mMaxPayloadSize, mMaxAttributesSize);
                 default:
                     should_not_get_here();
                 }

--- a/Framework/Source/Raytracing/RtProgramVars.cpp
+++ b/Framework/Source/Raytracing/RtProgramVars.cpp
@@ -64,21 +64,25 @@ namespace Falcor
     }
 
     template<typename ProgType>
-    void getSigSizeAndCreateVars(ProgType pProg, uint32_t& maxRootSigSize, GraphicsVars::SharedPtr pVars[], uint32_t varCount)
+    void createVars(ProgType pProg, GraphicsVars::SharedPtr pVars[], uint32_t varCount)
     {
-        RtProgramVersion::SharedConstPtr pVersion = pProg->getActiveVersion();
-        maxRootSigSize = max(pVersion->getLocalRootSignature()->getSizeInBytes(), maxRootSigSize);
+        ProgramVersion::SharedConstPtr pVersion = pProg->getActiveVersion();
         for(uint32_t i = 0 ; i < varCount ; i++)
         {
-            pVars[i] = GraphicsVars::create(pProg->getLocalReflector(), true, pVersion->getLocalRootSignature());
+            pVars[i] = GraphicsVars::create(pVersion->getLocalReflector(), true);
         }
+    }
+
+    template<typename ProgType>
+    void getSigSize(ProgType pProg, uint32_t& maxRootSigSize)
+    {
+        maxRootSigSize = max(pProg->getLocalRootSignature()->getSizeInBytes(), maxRootSigSize);
     }
 
     bool RtProgramVars::init()
     {
         // Find the max root-signature size and create the programVars
-        uint32_t maxRootSigSize = 0;
-        getSigSizeAndCreateVars(mpProgram->getRayGenProgram(), maxRootSigSize, &mRayGenVars, 1);
+        createVars(mpProgram->getRayGenProgram(), &mRayGenVars, 1);
 
         mHitProgCount = mpProgram->getHitProgramCount();
         mMissProgCount = mpProgram->getMissProgramCount();
@@ -86,13 +90,14 @@ namespace Falcor
         mMissVars.resize(mMissProgCount);
         mHitVars.resize(mHitProgCount);
         uint32_t recordCountPerHit = mpScene->getGeometryCount(mHitProgCount);
+        mRecordCountPerHit = recordCountPerHit;
 
         for (uint32_t i = 0 ; i < mHitProgCount; i++)
         {
             if(mpProgram->getHitProgram(i))
             {
                 mHitVars[i].resize(recordCountPerHit);
-                getSigSizeAndCreateVars(mpProgram->getHitProgram(i), maxRootSigSize, mHitVars[i].data(), recordCountPerHit);
+                createVars(mpProgram->getHitProgram(i), mHitVars[i].data(), recordCountPerHit);
             }
         }
 
@@ -100,7 +105,7 @@ namespace Falcor
         {
             if(mpProgram->getMissProgram(i))
             {
-                getSigSizeAndCreateVars(mpProgram->getMissProgram(i), maxRootSigSize, &mMissVars[i], 1);
+                createVars(mpProgram->getMissProgram(i), &mMissVars[i], 1);
             }
         }
 
@@ -114,17 +119,17 @@ namespace Falcor
         uint32_t numEntries = mMissProgCount + hitEntries + 1; // 1 is for the ray-gen
 
         // Calculate the record size
-        mRecordSize = mProgramIdentifierSize + maxRootSigSize;
-        mRecordSize = align_to(D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT, mRecordSize);
-        assert(mRecordSize != 0);
+//        mRecordSize = mProgramIdentifierSize + maxRootSigSize;
+//        mRecordSize = align_to(D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT, mRecordSize);
+//        assert(mRecordSize != 0);
 
         // Create the buffer and allocate the temporary storage
-        mpShaderTable = Buffer::create(numEntries * mRecordSize, Resource::BindFlags::ShaderResource, Buffer::CpuAccess::None);
-        assert(mpShaderTable);
-        mShaderTableData.resize(mpShaderTable->getSize());
+//        mpShaderTable = Buffer::create(numEntries * mRecordSize, Resource::BindFlags::ShaderResource, Buffer::CpuAccess::None);
+//        assert(mpShaderTable);
+//        mShaderTableData.resize(mpShaderTable->getSize());
 
         // Create the global variables
-        mpGlobalVars = GraphicsVars::create(mpProgram->getGlobalReflector(), true, mpProgram->getGlobalRootSignature());
+        mpGlobalVars = GraphicsVars::create(mpProgram->getGlobalReflector(), true);
 
         return true;
     }
@@ -143,42 +148,60 @@ namespace Falcor
     // The size of each record is mRecordSize
     // 
     // If this layout changes, we also need to change the constants kRayGenRecordIndex and kFirstMissRecordIndex
-
-    uint8_t* RtProgramVars::getRayGenRecordPtr()
-    {
-        return mShaderTableData.data() + (kRayGenRecordIndex * mRecordSize);
-    }
-
-    uint8_t* RtProgramVars::getMissRecordPtr(uint32_t missId)
-    {
-        assert(missId < mMissProgCount);
-        uint32_t offset = mRecordSize * (kFirstMissRecordIndex + missId);
-        return mShaderTableData.data() + offset;
-    }
-
-    uint8_t* RtProgramVars::getHitRecordPtr(uint32_t hitId, uint32_t meshId)
-    {   
-        assert(hitId < mHitProgCount);
-        uint32_t meshIndex = mFirstHitVarEntry + mHitProgCount * meshId;    // base record of the requested mesh
-        uint32_t recordIndex = meshIndex + hitId;
-        return mShaderTableData.data() + (recordIndex * mRecordSize);
-    }
-
-    bool applyRtProgramVars(uint8_t* pRecord, const RtProgramVersion* pProgVersion, const RtStateObject* pRtso, uint32_t progIdSize, ProgramVars* pVars, RtVarsContext* pContext)
+    
+    bool applyRtProgramVars(uint8_t* pRecord, const RtProgramKernels* pKernels, const RtStateObject* pRtso, uint32_t progIdSize, ProgramVars* pVars, RtVarsContext* pContext)
     {
         MAKE_SMART_COM_PTR(ID3D12StateObjectPropertiesPrototype);
         ID3D12StateObjectPropertiesPrototypePtr pRtsoPtr = pRtso->getApiHandle();
-        memcpy(pRecord, pRtsoPtr->GetShaderIdentifier(pProgVersion->getExportName().c_str()), progIdSize);
+        memcpy(pRecord, pRtsoPtr->GetShaderIdentifier(pKernels->getExportName().c_str()), progIdSize);
         pRecord += progIdSize;
-        pContext->getRtVarsCmdList()->setRootParams(pProgVersion->getLocalRootSignature(), pRecord);
-        return pVars->applyProgramVarsCommon<true>(pContext, true);
+        pContext->getRtVarsCmdList()->setRootParams(pKernels->getLocalRootSignature(), pRecord);
+        return pVars->applyProgramVarsCommon<true>(pContext, true, pKernels);
     }
 
     bool RtProgramVars::apply(RenderContext* pCtx, RtStateObject* pRtso)
     {
+        auto pPipelineKernels = pRtso->getKernels().get();
+
+        auto recordSize = pPipelineKernels->getRecordSize();
+
+        // Get the program identifier size
+        ID3D12DeviceRaytracingPrototypePtr pRtDevice = gpDevice->getApiHandle();
+        mProgramIdentifierSize = pRtDevice->GetShaderIdentifierSize();
+
+        // Create the shader-table buffer
+        uint32_t hitEntries = mRecordCountPerHit * mHitProgCount;
+        uint32_t numEntries = mMissProgCount + hitEntries + 1; // 1 is for the ray-gen
+
+        auto shaderTableSize = numEntries * recordSize;
+        if(shaderTableSize != mShaderTableData.size() )
+        {
+            // Create the buffer and allocate the temporary storage
+            mpShaderTable = Buffer::create(shaderTableSize, Resource::BindFlags::ShaderResource, Buffer::CpuAccess::None);
+            assert(mpShaderTable);
+            mShaderTableData.resize(shaderTableSize);
+        }
+
+        uint8_t* pRayGenRecord = mShaderTableData.data() + (kRayGenRecordIndex * recordSize);
+
+        auto getMissRecordPtr = [&](uint32_t missId)
+        {
+            assert(missId < mMissProgCount);
+            uint32_t offset = recordSize * (kFirstMissRecordIndex + missId);
+            return mShaderTableData.data() + offset;
+        };
+
+        auto getHitRecordPtr = [&](uint32_t hitId, uint32_t meshId)
+        {   
+            assert(hitId < mHitProgCount);
+            uint32_t meshIndex = mFirstHitVarEntry + mHitProgCount * meshId;    // base record of the requested mesh
+            uint32_t recordIndex = meshIndex + hitId;
+            return mShaderTableData.data() + (recordIndex * recordSize);
+        };
+
+
         // We always have a ray-gen program, apply it first
-        uint8_t* pRayGenRecord = getRayGenRecordPtr();
-        applyRtProgramVars(pRayGenRecord, mpProgram->getRayGenProgram()->getActiveVersion().get(), pRtso, mProgramIdentifierSize, getRayGenVars().get(), mpRtVarsHelper.get());
+        applyRtProgramVars(pRayGenRecord, pPipelineKernels->getRayGenProgram().get(), pRtso, mProgramIdentifierSize, getRayGenVars().get(), mpRtVarsHelper.get());
 
         // Loop over the rays
         uint32_t hitCount = mpProgram->getHitProgramCount();
@@ -189,7 +212,7 @@ namespace Falcor
                 for (uint32_t i = 0; i < mpScene->getGeometryCount(hitCount); i++)
                 {
                     uint8_t* pHitRecord = getHitRecordPtr(h, i);
-                    if (!applyRtProgramVars(pHitRecord, mpProgram->getHitProgram(h)->getActiveVersion().get(), pRtso, mProgramIdentifierSize, getHitVars(h)[i].get(), mpRtVarsHelper.get()))
+                    if (!applyRtProgramVars(pHitRecord, pPipelineKernels->getHitProgram(h).get(), pRtso, mProgramIdentifierSize, getHitVars(h)[i].get(), mpRtVarsHelper.get()))
                     {
                         return false;
                     }
@@ -202,14 +225,16 @@ namespace Falcor
             if(mpProgram->getMissProgram(m))
             {
                 uint8_t* pMissRecord = getMissRecordPtr(m);
-                if (!applyRtProgramVars(pMissRecord, mpProgram->getMissProgram(m)->getActiveVersion().get(), pRtso, mProgramIdentifierSize, getMissVars(m).get(), mpRtVarsHelper.get()))
+                if (!applyRtProgramVars(pMissRecord, pPipelineKernels->getMissProgram(m).get(), pRtso, mProgramIdentifierSize, getMissVars(m).get(), mpRtVarsHelper.get()))
                 {
                     return false;
                 }
             }
         }
 
-        mpGlobalVars->applyProgramVarsCommon<false>(pCtx, true);
+        // TODO: need a version of the pipeline info to pass in...
+
+        mpGlobalVars->applyProgramVarsCommon<false>(pCtx, true, pPipelineKernels->getGlobalProgram().get());
 
         pCtx->updateBuffer(mpShaderTable.get(), mShaderTableData.data());
         return true;

--- a/Framework/Source/Raytracing/RtProgramVars.h
+++ b/Framework/Source/Raytracing/RtProgramVars.h
@@ -55,7 +55,6 @@ namespace Falcor
         bool apply(RenderContext* pCtx, RtStateObject* pRtso);
 
         Buffer::SharedPtr getShaderTable() const { return mpShaderTable; }
-        uint32_t getRecordSize() const { return mRecordSize; }
         uint32_t getRayGenRecordIndex() const { return kRayGenRecordIndex; }
         uint32_t getFirstMissRecordIndex() const { return kFirstMissRecordIndex; }
         uint32_t getFirstHitRecordIndex() const { return mFirstHitVarEntry; }
@@ -73,13 +72,8 @@ namespace Falcor
         RtProgramVars(RtProgram::SharedPtr pProgram, RtScene::SharedPtr pScene);
         RtProgram::SharedPtr mpProgram;
         RtScene::SharedPtr mpScene;
-        uint32_t mRecordSize;
         uint32_t mProgramIdentifierSize;
         Buffer::SharedPtr mpShaderTable;
-
-        uint8_t* getRayGenRecordPtr();
-        uint8_t* getMissRecordPtr(uint32_t missId);
-        uint8_t* getHitRecordPtr(uint32_t hitId, uint32_t meshId);
 
         bool init();
 
@@ -89,5 +83,8 @@ namespace Falcor
         std::vector<uint8_t> mShaderTableData;
         VarsVector mMissVars;
         RtVarsContext::SharedPtr mpRtVarsHelper;
+
+//        uint32_t mRecordSize;
+        uint32_t mRecordCountPerHit;
     };
 }

--- a/Framework/Source/Raytracing/RtSceneRenderer.cpp
+++ b/Framework/Source/Raytracing/RtSceneRenderer.cpp
@@ -201,11 +201,12 @@ namespace Falcor
             }
         }
 
-        if (!pRtVars->apply(pContext, pState->getRtso().get()))
+        auto pRtso = pState->getRtso(pRtVars.get());
+        if (!pRtVars->apply(pContext, pRtso.get()))
         {
             logError("RtSceneRenderer::renderScene() - applying RtProgramVars failed, most likely because we ran out of descriptors.", true);
             assert(false);
         }
-        pContext->raytrace(pRtVars, pState, targetDim.x, targetDim.y);
+        pContext->raytrace(pRtVars, pRtso, targetDim.x, targetDim.y);
     }
 }

--- a/Framework/Source/Raytracing/RtState.h
+++ b/Framework/Source/Raytracing/RtState.h
@@ -41,22 +41,24 @@ namespace Falcor
         static SharedPtr create();
         ~RtState();
 
-        void setProgram(RtProgram::SharedPtr pProg) { mpProgram = pProg; }
-        RtProgram::SharedPtr getProgram() const { return mpProgram; }
+        void setProgram(RtPipelineVersion::SharedConstPtr pProg) { mpProgram = pProg; }
+        RtPipelineVersion::SharedConstPtr getProgram() const { return mpProgram; }
+
+        void setProgram(RtProgram::SharedPtr pProg) { setProgram(pProg->getActiveVersion()); }
 
         void setMaxTraceRecursionDepth(uint32_t maxDepth);
         uint32_t getMaxTraceRecursionDepth() const { return mMaxTraceRecursionDepth; }
 
         void setProgramStackSize(uint32_t stackSize);
 
-        RtStateObject::SharedPtr getRtso();
+        RtStateObject::SharedPtr getRtso(RtProgramVars* pVars);
     private:
         RtState();
-        RtProgram::SharedPtr mpProgram;
+        RtPipelineVersion::SharedConstPtr mpProgram;
         uint32_t mMaxTraceRecursionDepth = 1;
         using StateGraph = Graph<RtStateObject::SharedPtr, void*>;
         StateGraph::SharedPtr mpRtsoGraph;
 
-        RtStateObject::ProgramList createProgramList() const;
+//        RtStateObject::ProgramList createProgramList(RtProgramVars* pVars) const;
     };
 }

--- a/Framework/Source/Raytracing/RtStateObject.cpp
+++ b/Framework/Source/Raytracing/RtStateObject.cpp
@@ -38,15 +38,7 @@ namespace Falcor
     {
         bool b = true;
         b = b && (mMaxTraceRecursionDepth == other.mMaxTraceRecursionDepth);
-        b = b && (mProgList.size() == other.mProgList.size());
-
-        if (b)
-        {
-            for (size_t i = 0; i < mProgList.size(); i++)
-            {
-                b = b && (mProgList[i] == other.mProgList[i]);
-            }
-        }
+        b = b && (mpKernels == other.mpKernels);
         return b;
     }
     
@@ -59,9 +51,9 @@ namespace Falcor
         rtsoHelper.addPipelineConfig(desc.mMaxTraceRecursionDepth);
 
         // Loop over the programs
-        for (const auto& pProg : pState->getProgramList())
+        for (const auto& pProg : desc.mpKernels->getProgramList())
         {
-            if (pProg->getType() == RtProgramVersion::Type::Hit)
+            if (pProg->getType() == RtProgramKernels::Type::Hit)
             {
                 const RtShader* pIntersection = pProg->getShader(ShaderType::Intersection).get();
                 const RtShader* pAhs = pProg->getShader(ShaderType::AnyHit).get();
@@ -80,7 +72,7 @@ namespace Falcor
             }
             else
             {
-                const RtShader* pShader = pProg->getShader(pProg->getType() == RtProgramVersion::Type::Miss ? ShaderType::Miss : ShaderType::RayGeneration).get();
+                const RtShader* pShader = pProg->getShader(pProg->getType() == RtProgramKernels::Type::Miss ? ShaderType::Miss : ShaderType::RayGeneration).get();
                 rtsoHelper.addProgramDesc(pShader->getD3DBlob(), pProg->getExportName());
             }
 

--- a/Framework/Source/Raytracing/RtStateObject.h
+++ b/Framework/Source/Raytracing/RtStateObject.h
@@ -37,18 +37,16 @@ namespace Falcor
         using SharedConstPtr = std::shared_ptr<const RtStateObject>;
         using ApiHandle = ID3D12StateObjectPrototypePtr;
 
-        using ProgramList = std::vector<RtProgramVersion::SharedConstPtr>;
-
         class Desc
         {
         public:
-            Desc& setProgramList(const ProgramList& list) { mProgList = list; return *this; }
+            Desc& setKernels(RtPipelineKernels::SharedConstPtr const& pKernels) { mpKernels = pKernels; return *this; }
             Desc& setMaxTraceRecursionDepth(uint32_t maxDepth) { mMaxTraceRecursionDepth = maxDepth; return *this; }
             Desc& setGlobalRootSignature(const std::shared_ptr<RootSignature>& pRootSig) { mpGlobalRootSignature = pRootSig; return *this; }
             bool operator==(const Desc& other) const;
 
         private:
-            ProgramList mProgList;
+            RtPipelineKernels::SharedConstPtr mpKernels;
             std::shared_ptr<RootSignature> mpGlobalRootSignature;
             uint32_t mMaxTraceRecursionDepth = 1;
             friend RtStateObject;
@@ -57,7 +55,7 @@ namespace Falcor
         static SharedPtr create(const Desc& desc);
         const ApiHandle& getApiHandle() const { return mApiHandle; }
 
-        const ProgramList& getProgramList() const { return mDesc.mProgList; }
+        RtPipelineKernels::SharedConstPtr const& getKernels() const { return mDesc.mpKernels; }
         uint32_t getMaxTraceRecursionDepth() const { return mDesc.mMaxTraceRecursionDepth; }
         const std::shared_ptr<RootSignature>& getGlobalRootSignature() const { return mDesc.mpGlobalRootSignature; }
         const Desc& getDesc() const { return mDesc; }

--- a/Framework/Source/Utils/VariablesBufferUI.cpp
+++ b/Framework/Source/Utils/VariablesBufferUI.cpp
@@ -284,9 +284,6 @@ namespace Falcor
             // begin recursion on first struct
             renderUIInternal(pGui, pStruct, "", 0, mVariablesBufferRef.mDirty);
 
-            // dirty flag for uploading will be set by GUI
-            mVariablesBufferRef.uploadToGPU();
-
             if(uiGroup != nullptr) pGui->endGroup();
         }
     }


### PR DESCRIPTION
At a high level, the ability to use shader components means that a programmer can use (global) generic type parameters in their shader code:

```hlsl
// MyProgram.slang
interface IFrobnicator { ... }
struct SimpleFrobnicator : IFrobnicator { ... };

type_param F : IFrobnicator;
ParameterBlock<F> gFrobnicator;

void main(...) { gFrobnicator.frobincate(...); }
```

Then in the host code, they can load `MyProgram.slang`, create a `ProgramVars` from it, etc., but before they render they need to set the `gFrobnicator` parameter block to a parameter block they created manually from a type (such as `SimpleFrobnicator`). At that point the Slang compiler gets invoked to generate final kernel code specialized to the chosen type, by inferring that the `F` type parameter should be set to `SimpleFrobnicator` based on what was boudn to `gFrobnicator`.

Actually achieving this goal involves several big changes to how Falcor handles shader compilation.

The `ProgramVersion` type no longer represents the final compiled shader kernels. Instead, a `ProgramVersion` just represents the input Slang/HLSL code (from the `Program::Desc`) plus any `#define`s that have been set. This is enough to invoke the Slang compiler with code generation disabled, and get back reflection information, which is what the `preprocessAndCreateProgramVersion` function now does. It is still possible to create a `ProgramVars` from just a `ProgramVersion`.

In order to create actual executable kernels, we must combine a specific `ProgramVersion` (which knows the Slang code to use) with a `ProgramVars` (which knows the types bound for various parameter blocks), to create a new type called `ProgramKernels` which simply encapsulates all the compiled kernels for that program specialized to particular types. In the current common case where there are *no* type parameters, there will only be one `ProgramKernels` for each `ProgramVersion`.

The combination of a program version with program vars is handled in `getCSO`, `getGSO`, etc. These function already took the `ProgramVars` as an argument, so it seems like we were heading in this direction anyway.

In order to support specialization based on the types in parameter blocks, `ParameterBlock` now tracks the type name of its contents, along with a "type ID" that is used when doing specialization (to avoid string-based lookups). The `preprocessAndCreateProgramKernels` function creates kernel code for a particular specialization, and we try to share as much of the Slang logic between this and the `ProgramVersion` generation.

Root signatures probably shouldn't have belonged to `ProgramVars` in the first place, but once we have generic type parameters in the mix it becomes clear that the final root signature can't be fully known until we have the concrete type arguments. For example, the type parameter `F` could be filled in with an empty type (no need to allocate a descriptor set at all for `gFrobnicator`), or a type that recursively contains some `ParameterBlocks` (so that `gFrobnicator` could map to *multiple* descriptor sets).

In the new code, the root signature is part of the `ProgramKernels`. This means that the subroutines for binding data from a `ProgramVars` (which also end up binding root signatures) now take the kernels as an argument, both so that they can extract the root signature when binding it, but also so that they can look up the mapping from their parmaeter blocks to the corresponding root indices.

The way that local/global/all reflectors were stored in a `ProgramVersion` made it hard to get that information out at the right time, so the `ProgramReflectors` have been moved into `ProgramVersion`. The feature was only there for RT programs, but the space was already being consumed for all programs anyway.

Mirroring the split into `Program`, `ProgramVersion`, and `ProgramKernels` in the rasterization case, we now have `RtProgram`, `RtPipelineVersion` and `RtPipelineKernels`. Note that the use of "Pipeline" rather than "Program" in the names is meant to be accurate, since an `RtProgram` is currently actually a *container* for `Program`s.

Just as in the rasterization case, an `RtPipelineVersion` is an `RtProgram` specialized to particular `#define`s, while an `RtPipelineKernels` collects specialized kernels based on the types bound in the various `ProgramVars`. The `RtPipelineKernels` thus fills a similar role to the `ProgramList` in the previous code.

The actual shader table storage has been left in the `RtProgramVars`, although the logic to compute the required record size has migrated to `RtPipelineKernels` because it depends on the actual compiled code.

One somewhat complicated contrivance is that we maintain a "global kernels" object to encapsulate the root signature and root parmameter mapping associated with the global parameters. This is fine by the abstraction (a kernels object can hold zero or more compiled kernels), but still a little weird.

In the context of RT, specialization is only supported for type parameters in the local root signature, but extending support to allow type parameters in the global root signature seems like an important step going forward. There is also no support for having different specializations of the same program manifest in an `RtProgramVars`, but that is similarly an important next step.