### PR TITLE
Commandlist recording with multi render context in multi thread mode

### DIFF
--- a/Framework/Source/API/ConstantBuffer.cpp
+++ b/Framework/Source/API/ConstantBuffer.cpp
@@ -72,16 +72,21 @@ namespace Falcor
 
     bool ConstantBuffer::uploadToGPU(size_t offset, size_t size)
     {
-        if (mDirty) mpCbv = nullptr;
-        return VariablesBuffer::uploadToGPU(offset, size);
+		EnterCriticalSection(&ghMutex);
+        if (mDirty) mpCbv = nullptr; //cinetec mod:dx12
+		bool res= VariablesBuffer::uploadToGPU(offset, size);
+		LeaveCriticalSection(&ghMutex);
+		return res;
     }
 
     ConstantBufferView::SharedPtr ConstantBuffer::getCbv() const
     {
+		EnterCriticalSection(&ghMutex);
         if (mpCbv == nullptr)
         {
             mpCbv = ConstantBufferView::create(Resource::shared_from_this());
         }
+		LeaveCriticalSection(&ghMutex);
         return mpCbv;
     }
 }

--- a/Framework/Source/API/ConstantBuffer.cpp
+++ b/Framework/Source/API/ConstantBuffer.cpp
@@ -72,21 +72,16 @@ namespace Falcor
 
     bool ConstantBuffer::uploadToGPU(size_t offset, size_t size)
     {
-		EnterCriticalSection(&ghMutex);
-        if (mDirty) mpCbv = nullptr; //cinetec mod:dx12
-		bool res= VariablesBuffer::uploadToGPU(offset, size);
-		LeaveCriticalSection(&ghMutex);
-		return res;
+        if (mDirty) mpCbv = nullptr;
+        return VariablesBuffer::uploadToGPU(offset, size);
     }
 
     ConstantBufferView::SharedPtr ConstantBuffer::getCbv() const
     {
-		EnterCriticalSection(&ghMutex);
         if (mpCbv == nullptr)
         {
             mpCbv = ConstantBufferView::create(Resource::shared_from_this());
         }
-		LeaveCriticalSection(&ghMutex);
         return mpCbv;
     }
 }

--- a/Framework/Source/API/D3D12/D3D12RenderContext.cpp
+++ b/Framework/Source/API/D3D12/D3D12RenderContext.cpp
@@ -345,33 +345,7 @@ namespace Falcor
     {
         drawIndexedInstanced(indexCount, 1, startIndexLocation, baseVertexLocation, 0);
     }
-	/////////////////////////////////////////////////////////
-	//	right now Falcor use a global state for one resource, so if we call D3D12SetFbo in multithread mode, there will be conflict.
-	//  so we set the FBO before the multithreading and we don't set FBO again for every object drawing in multithreading. Afterwards we set bind flags back to ALL.
-	// 	1. for (int i = 0; i < n; i++) //n threads
-	// 	{
-	//
-	//	 getRenderContext(i)->prepareForDrawLocal(Falcor::RenderContext::StateBindFlags::Fbo);
-	//	}
-	//
-	//	2. Call drawIndexedInstancedMultiThread in thread instead of drawIndexedInstanced
-	//
-	//	3.  for (int i = 0; i < n; i++) //n threads
-	//		getRenderContext(i)->setBindFlags(Falcor::RenderContext::StateBindFlags::All);
-	//////////////////////////////////////////////////////////
-	void RenderContext::prepareForDrawLocal()
-	{
-		D3D12SetFbo(this, mpGraphicsState->getFbo().get());
-	}
-	
-	void RenderContext::drawIndexedInstancedMultiThread(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, int32_t baseVertexLocation, uint32_t startInstanceLocation)
-	{
-		setBindFlags( Falcor::RenderContext::StateBindFlags::All & ~Falcor::RenderContext::StateBindFlags::Fbo);
-		prepareForDraw();
-		mpLowLevelData->getCommandList()->DrawIndexedInstanced(indexCount, instanceCount, startIndexLocation, baseVertexLocation, startInstanceLocation);
-		setBindFlags(Falcor::RenderContext::StateBindFlags::All);
-	}
-	
+
     void RenderContext::drawIndirect(const Buffer* argBuffer, uint64_t argBufferOffset)
     {
         prepareForDraw();

--- a/Framework/Source/API/D3D12/D3D12RenderContext.cpp
+++ b/Framework/Source/API/D3D12/D3D12RenderContext.cpp
@@ -345,7 +345,33 @@ namespace Falcor
     {
         drawIndexedInstanced(indexCount, 1, startIndexLocation, baseVertexLocation, 0);
     }
-
+	/////////////////////////////////////////////////////////
+	//	right now Falcor use a global state for one resource, so if we call D3D12SetFbo in multithread mode, there will be conflict.
+	//  so we set the FBO before the multithreading and we don't set FBO again for every object drawing in multithreading. Afterwards we set bind flags back to ALL.
+	// 	1. for (int i = 0; i < n; i++) //n threads
+	// 	{
+	//
+	//	 getRenderContext(i)->prepareForDrawLocal(Falcor::RenderContext::StateBindFlags::Fbo);
+	//	}
+	//
+	//	2. Call drawIndexedInstancedMultiThread in thread instead of drawIndexedInstanced
+	//
+	//	3.  for (int i = 0; i < n; i++) //n threads
+	//		getRenderContext(i)->setBindFlags(Falcor::RenderContext::StateBindFlags::All);
+	//////////////////////////////////////////////////////////
+	void RenderContext::prepareForDrawLocal()
+	{
+		D3D12SetFbo(this, mpGraphicsState->getFbo().get());
+	}
+	
+	void RenderContext::drawIndexedInstancedMultiThread(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, int32_t baseVertexLocation, uint32_t startInstanceLocation)
+	{
+		setBindFlags( Falcor::RenderContext::StateBindFlags::All & ~Falcor::RenderContext::StateBindFlags::Fbo);
+		prepareForDraw();
+		mpLowLevelData->getCommandList()->DrawIndexedInstanced(indexCount, instanceCount, startIndexLocation, baseVertexLocation, startInstanceLocation);
+		setBindFlags(Falcor::RenderContext::StateBindFlags::All);
+	}
+	
     void RenderContext::drawIndirect(const Buffer* argBuffer, uint64_t argBufferOffset)
     {
         prepareForDraw();

--- a/Framework/Source/Graphics/GraphicsState.cpp
+++ b/Framework/Source/Graphics/GraphicsState.cpp
@@ -70,7 +70,6 @@ namespace Falcor
     GraphicsStateObject::SharedPtr GraphicsState::getGSO(const GraphicsVars* pVars)
     {
         assert(mpVao);
-		EnterCriticalSection(&ghMutex);
         if (mpProgram && mpVao->getVertexLayout() != nullptr)
         {
             mpVao->getVertexLayout()->addVertexAttribDclToProg(mpProgram.get());
@@ -127,7 +126,6 @@ namespace Falcor
                 mpGsoGraph->setCurrentNodeData(pGso);
             }
         }
-		LeaveCriticalSection(&ghMutex);
         return pGso;
     }
 

--- a/Framework/Source/Graphics/GraphicsState.cpp
+++ b/Framework/Source/Graphics/GraphicsState.cpp
@@ -70,6 +70,7 @@ namespace Falcor
     GraphicsStateObject::SharedPtr GraphicsState::getGSO(const GraphicsVars* pVars)
     {
         assert(mpVao);
+		EnterCriticalSection(&ghMutex);
         if (mpProgram && mpVao->getVertexLayout() != nullptr)
         {
             mpVao->getVertexLayout()->addVertexAttribDclToProg(mpProgram.get());
@@ -126,6 +127,7 @@ namespace Falcor
                 mpGsoGraph->setCurrentNodeData(pGso);
             }
         }
+		LeaveCriticalSection(&ghMutex);
         return pGso;
     }
 

--- a/Framework/Source/Graphics/Program/ParameterBlock.cpp
+++ b/Framework/Source/Graphics/Program/ParameterBlock.cpp
@@ -648,11 +648,9 @@ namespace Falcor
             mRootSets[i].dirty = (mRootSets[i].pSet == nullptr);
             if (mRootSets[i].pSet == nullptr)
             {
-				EnterCriticalSection(&ghMutex);
                 DescriptorSet::Layout layout;
                 const auto& set = mpReflector->getDescriptorSetLayouts()[i];
                 mRootSets[i].pSet = DescriptorSet::create(gpDevice->getGpuDescriptorPool(), set);
-				LeaveCriticalSection(&ghMutex);
                 if (mRootSets[i].pSet == nullptr)
                 {
                     return false;

--- a/Framework/Source/Graphics/Program/ParameterBlock.cpp
+++ b/Framework/Source/Graphics/Program/ParameterBlock.cpp
@@ -648,9 +648,11 @@ namespace Falcor
             mRootSets[i].dirty = (mRootSets[i].pSet == nullptr);
             if (mRootSets[i].pSet == nullptr)
             {
+				EnterCriticalSection(&ghMutex);
                 DescriptorSet::Layout layout;
                 const auto& set = mpReflector->getDescriptorSetLayouts()[i];
                 mRootSets[i].pSet = DescriptorSet::create(gpDevice->getGpuDescriptorPool(), set);
+				LeaveCriticalSection(&ghMutex);
                 if (mRootSets[i].pSet == nullptr)
                 {
                     return false;


### PR DESCRIPTION
Each RenderContex has a different GraphicsVars. This commit adds criticial sections to allow multithreading and provides a method to avoid crash of resources with global state.