### PR TITLE
Enable CI on Windows with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Falcor 3.2
+Falcor 3.2 [![Build Status](https://ci.appveyor.com/api/projects/status/github/NVIDIAGameWorks/Falcor?branch=master&svg=true)](https://ci.appveyor.com/project/NVIDIAGameWorks/Falcor)
 =================
 
 Falcor is a real-time rendering framework supporting DirectX 12 and Vulkan. It aims to improve productivity of research and prototype projects.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ artifacts:
    path: Bin\Int\x64\Release*\Lib\Falcor.lib
  - name: "FalcorSharedObjects.lib (x64)"
    path: lib.zip
- - name: "All release .lib's (x64)"
+ - name: "All release .lib files (x64)"
    path: lib.zip
- - name: "All release .exe's (x64)"
+ - name: "All release .exe files (x64)"
    path: exe.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,10 @@
 image: Visual Studio 2017
-configuration: Release
+configuration:
+ - ReleaseD3D12
+ - ReleaseVK
 
 build:
   project: Falcor.sln
 
 artifacts:
- - path: cmake_build\Release\*.*
+ - path: cmake_build\Release*\**\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,4 +7,5 @@ build:
   project: Falcor.sln
 
 artifacts:
- - path: cmake_build\**\Release*\**\*.*
+ - path: falcor\**\Release*\**\*.exe
+ - path: falcor\**\Release*\**\*.lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ artifacts:
  - name: "Falcor.lib (x64)"
    path: Bin\Int\x64\Release*\Lib\Falcor.lib
  - name: "FalcorSharedObjects.lib (x64)"
-   path: lib.zip
+   path: Bin\x64\Release\FalcorSharedObjects.lib
  - name: "All release .lib files (x64)"
    path: lib.zip
  - name: "All release .exe files (x64)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,16 @@ configuration:
 build:
   project: Falcor.sln
 
+before_package:
+ - 7z a lib1.zip Bin\**\Release*\**\*.lib
+ - 7z a exe1.zip Bin\**\Release*\**\*.exe
+ - 7z a lib2.zip .\Bin\**\Release*\**\*.lib
+ - 7z a exe2.zip .\Bin\**\Release*\**\*.exe
+ 
 artifacts:
+ - path: exe1.zip
+ - path: lib1.zip
+ - path: exe2.zip
+ - path: lib2.zip
  - path: Bin\**\Release*\**\*.exe
  - path: Bin\**\Release*\**\*.lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+image: Visual Studio 2017
+
+build:
+  project: Falcor.sln
+
+artifacts:
+ - path: cmake_build\Release\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 image: Visual Studio 2017
+configuration: Release
 
 build:
   project: Falcor.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,4 +7,4 @@ build:
   project: Falcor.sln
 
 artifacts:
- - path: cmake_build\Release*\**\*.*
+ - path: cmake_build\**\Release*\**\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,5 +7,5 @@ build:
   project: Falcor.sln
 
 artifacts:
- - path: falcor\**\Release*\**\*.exe
- - path: falcor\**\Release*\**\*.lib
+ - path: Bin\**\Release*\**\*.exe
+ - path: Bin\**\Release*\**\*.lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,15 +7,15 @@ build:
   project: Falcor.sln
 
 before_package:
- - 7z a lib1.zip Bin\**\Release*\**\*.lib
- - 7z a exe1.zip Bin\**\Release*\**\*.exe
- - 7z a lib2.zip .\Bin\**\Release*\**\*.lib
- - 7z a exe2.zip .\Bin\**\Release*\**\*.exe
+ - 7z a lib.zip Bin\x64\Release\ *.lib
+ - 7z a exe.zip Bin\x64\Release\ *.exe
  
 artifacts:
- - path: exe1.zip
- - path: lib1.zip
- - path: exe2.zip
- - path: lib2.zip
- - path: Bin\**\Release*\**\*.exe
- - path: Bin\**\Release*\**\*.lib
+ - name: "Falcor.lib (x64)"
+   path: Bin\Int\x64\Release*\Lib\Falcor.lib
+ - name: "FalcorSharedObjects.lib (x64)"
+   path: lib.zip
+ - name: "All release .lib's (x64)"
+   path: lib.zip
+ - name: "All release .exe's (x64)"
+   path: exe.zip


### PR DESCRIPTION
Enables continuous integration on Windows with AppVeyor. Example can be found [here](https://ci.appveyor.com/project/EwoutH/falcor).

AppVeyor only needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.