### PR TITLE
Fix gcc-8 warnings

### DIFF
--- a/Framework/Externals/dear_imgui_addons/imguinodegrapheditor/imguinodegrapheditor.cpp
+++ b/Framework/Externals/dear_imgui_addons/imguinodegrapheditor/imguinodegrapheditor.cpp
@@ -1916,7 +1916,7 @@ namespace ImGui {
             }
             if (tmp && Count < IMGUINODE_MAX_SLOTS) {
                 length = (int)strlen(tmp); if (length >= IMGUINODE_MAX_SLOT_NAME_LENGTH) length = IMGUINODE_MAX_SLOT_NAME_LENGTH - 1;
-                strncpy(Names[Count], tmp, length);
+                memcpy(Names[Count], tmp, length);
                 Names[Count][length] = '\0';
                 ++Count;
             }

--- a/Framework/Source/Experimental/RenderGraph/RenderGraphScripting.cpp
+++ b/Framework/Source/Experimental/RenderGraph/RenderGraphScripting.cpp
@@ -134,7 +134,7 @@ namespace Falcor
             mContext.getObject<RenderGraph::SharedPtr>(name);
             logWarning("RenderGraph `" + name + "` already exists. Replacing the current object");
         }
-        catch (std::exception) {}
+        catch (const std::exception &e) {}
         mContext.setObject(name, pGraph);
     }
 
@@ -144,7 +144,7 @@ namespace Falcor
         {
             return mContext.getObject<RenderGraph::SharedPtr>(name);
         }
-        catch (std::exception) 
+        catch (const std::exception &e)
         {
             logWarning("Can't find RenderGraph `" + name + "` in RenderGraphScriptContext");
             return nullptr;

--- a/Framework/Source/Graphics/Model/Loaders/BinaryModelImporter.cpp
+++ b/Framework/Source/Graphics/Model/Loaders/BinaryModelImporter.cpp
@@ -90,7 +90,7 @@ namespace Falcor
         uint32_t texCrdCount,
         glm::vec3* bitangentData)
     {
-        std::memset(bitangentData, 0, vertexCount * sizeof(vec3));
+        std::memset(static_cast<void*>(bitangentData), 0, vertexCount * sizeof(vec3));
 
         // calculate the tangent and bitangent for every face
         size_t primCount = indices.size() / 3;

--- a/Framework/Source/UnitTest.cpp
+++ b/Framework/Source/UnitTest.cpp
@@ -109,14 +109,14 @@ namespace Falcor
                 if (t.cpuFunc) t.cpuFunc(cpuCtx);
                 else t.gpuFunc(gpuCtx);
             }
-            catch (ErrorRunningTestException e)
+            catch (const ErrorRunningTestException &e)
             {
                 status = "SKIPPED";
                 failureDetails = "    ";
                 failureDetails += e.what();
                 failureDetails += "\n";
             }
-            catch (TooManyFailedTestsException e)
+            catch (const TooManyFailedTestsException &e)
             {
                 status = "ABORTED";
                 failureDetails = "    Gave up after " + std::to_string(kMaxTestFailures) + " failures.\n";


### PR DESCRIPTION
This fixes the following warnings:
catch-value
class-memaccess
class-memaccess
stringop-overflow