### PR TITLE
Fix compilation under Visual Studio 2019 16.7

### DIFF
--- a/Source/Falcor/Core/API/D3D12/D3D12Device.cpp
+++ b/Source/Falcor/Core/API/D3D12/D3D12Device.cpp
@@ -345,7 +345,7 @@ namespace Falcor
                 if (FAILED(mApiHandle->CreateCommandQueue(&cqDesc, IID_PPV_ARGS(&pQueue))))
                 {
                     logError("Failed to create command queue");
-                    return nullptr;
+                    return false;
                 }
 
                 mCmdQueues[i].push_back(pQueue);

--- a/Source/Falcor/Core/API/D3D12/D3D12Shader.cpp
+++ b/Source/Falcor/Core/API/D3D12/D3D12Shader.cpp
@@ -77,7 +77,7 @@ namespace Falcor
 
         if (pData->pBlob == nullptr)
         {
-            return nullptr;
+            return false;
         }
 
         mApiHandle = { pData->pBlob->GetBufferPointer(), pData->pBlob->GetBufferSize() };


### PR DESCRIPTION
This fixes the following error:

```
1>[…]Source\Falcor\Core\API\D3D12\D3D12Shader.cpp(80,27): error C2440: 'return': cannot convert from 'nullptr' to 'bool'
1>[…]Source\Falcor\Core\API\D3D12\D3D12Shader.cpp(80,20): message : conversion from 'nullptr_t' to 'bool' requires direct-initialization
```

and a similar error in _Source\Falcor\Core\API\D3D12\D3D12Device.cpp_