### PR TITLE
Always associate a camera to its scene graph node

### DIFF
--- a/Source/Falcor/Scene/Importers/AssimpImporter.cpp
+++ b/Source/Falcor/Scene/Importers/AssimpImporter.cpp
@@ -305,9 +305,9 @@ namespace Falcor
                     // GLTF2 already uses -Z view direction convention in Assimp, FBX does not
                     if (importMode != ImportMode::GLTF2) n.transform[2] = -n.transform[2];
                     nodeID = data.builder.addNode(n);
+                    pCamera->setNodeID(nodeID);
                     if (data.builder.isNodeAnimated(nodeID))
                     {
-                        pCamera->setNodeID(nodeID);
                         pCamera->setHasAnimation(true);
                         data.builder.setNodeInterpolationMode(nodeID, kCameraInterpolationMode, kCameraEnableWarping);
                     }


### PR DESCRIPTION
Cameras in assimp are expressed relative to the coordinate system defined by their scene graph node, regardless of whether that node is animated or not.