### PR TITLE
Lower the placement of labels in ComparisonPass

### DIFF
--- a/Source/RenderPasses/DebugPasses/ComparisonPass.cpp
+++ b/Source/RenderPasses/DebugPasses/ComparisonPass.cpp
@@ -111,12 +111,12 @@ void ComparisonPass::execute(RenderContext* pContext, const RenderData& renderDa
 
         // Draw text labeling the right side image
         std::string rightSide = mSwapSides ? mLeftLabel : mRightLabel;
-        TextRenderer::render(pContext, rightSide.c_str(), pDstFbo, float2(screenLoc + 16, 16));
+        TextRenderer::render(pContext, rightSide.c_str(), pDstFbo, float2(screenLoc + 16, 48));
 
         // Draw text labeling the left side image
         std::string leftSide = mSwapSides ? mRightLabel : mLeftLabel;
         uint32_t leftLength = uint32_t(leftSide.length()) * 9;
-        TextRenderer::render(pContext, leftSide.c_str(), pDstFbo, float2(screenLoc - 16 - leftLength, 16));
+        TextRenderer::render(pContext, leftSide.c_str(), pDstFbo, float2(screenLoc - 16 - leftLength, 48));
     }
 }
 


### PR DESCRIPTION
The initial offset from the top of the window was fine, until the menu bar was added which ended up covering the labels.
Increase the offset to take the height of the menu bar into account.