### PR TITLE
Additional fixes

### DIFF
--- a/Source/Falcor/Scene/Importers/AssimpImporter.cpp
+++ b/Source/Falcor/Scene/Importers/AssimpImporter.cpp
@@ -289,7 +289,7 @@ namespace Falcor
                 // Some importers don't provide the aspect ratio, use default for that case.
                 float aspectRatio = pAiCamera->mAspect != 0.f ? pAiCamera->mAspect : pCamera->getAspectRatio();
                 // Load focal length only when using GLTF2, use fixed 35mm for backwards compatibility with FBX files.
-                float focalLength = importMode == ImportMode::GLTF2 ? fovYToFocalLength(pAiCamera->mHorizontalFOV * 2 / aspectRatio, pCamera->getFrameHeight()) : 35.f;
+                float focalLength = importMode == ImportMode::GLTF2 ? fovYToFocalLength(pAiCamera->mHorizontalFOV / aspectRatio, pCamera->getFrameHeight()) : 35.f;
                 pCamera->setFocalLength(focalLength);
                 pCamera->setAspectRatio(aspectRatio);
                 pCamera->setDepthRange(pAiCamera->mClipPlaneNear, pAiCamera->mClipPlaneFar);

--- a/Source/Mogwai/Mogwai.vcxproj
+++ b/Source/Mogwai/Mogwai.vcxproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <None Include="Data\BSDFViewer.py" />
     <None Include="Data\config.py" />
-    <None Include="Data\forward_renderer.py" />
+    <None Include="Data\ForwardRenderer.py" />
     <None Include="Data\PathTracer.py" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Source/Mogwai/Mogwai.vcxproj.filters
+++ b/Source/Mogwai/Mogwai.vcxproj.filters
@@ -52,7 +52,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Data\forward_renderer.py">
+    <None Include="Data\ForwardRenderer.py">
       <Filter>Data</Filter>
     </None>
     <None Include="Data\config.py">


### PR DESCRIPTION
A couple small fixes:
* The ForwardRenderer.py script was renamed in an earlier version, but the Mogwai project still referred to the old name.
* When computing the focal length for cameras from glTF scenes, the code doubled the horizontal field of view angle exposed by assimp even though that variable already represented the whole field of view.