### PR TITLE
Corrected discrepancy for alpha testing between GBuffer pass and dept…

### DIFF
--- a/Source/RenderPasses/GBuffer/GBuffer/GBufferRaster.cpp
+++ b/Source/RenderPasses/GBuffer/GBuffer/GBufferRaster.cpp
@@ -84,7 +84,7 @@ GBufferRaster::GBufferRaster(const Dictionary& dict)
     parseDictionary(dict);
 
     // Create raster program
-    Program::DefineList defines = { { "_DEFAULT_ALPHA_TEST", "" } };
+    Program::DefineList defines = { };
     Program::Desc desc;
     desc.addShaderLibrary(kProgramFile).vsEntry("vsMain").psEntry("psMain");
     desc.setShaderModel(shaderModel);


### PR DESCRIPTION
Corrects discrepancy in GBuffer for alpha test between depth prepass and actual GBuffer creation, which would lead to artifacts (missing fragments/holes) in extreme cases (see below).

_DEFAULT_ALPHA_TEST was defined for GBuffer generation, but not for depth prepass.

It should be noted that the name "_DEFAULT_ALPHA_TEST" is perhaps misleading, since when not specified, a different alpha test is used instead. Hence, the "default" setting is actually not the default. 

GBuffer Normals rendered:
![shot2](https://user-images.githubusercontent.com/40643808/106813690-a1fd4600-6671-11eb-9335-5236e2a15cfc.png)
Closeup before:
![before2](https://user-images.githubusercontent.com/40643808/106813703-a9bcea80-6671-11eb-8e18-9912c895654d.png)
Closeup after:
![after2](https://user-images.githubusercontent.com/40643808/106813721-af1a3500-6671-11eb-8a5c-50a2e9afbf5d.png)