### PR TITLE
Allow customising the shader model of RtPrograms

### DIFF
--- a/Source/Falcor/Raytracing/RtProgram/RtProgram.h
+++ b/Source/Falcor/Raytracing/RtProgram/RtProgram.h
@@ -95,6 +95,8 @@ namespace Falcor
             */
             Desc& setCompilerFlags(Shader::CompilerFlags flags) { mBaseDesc.setCompilerFlags(flags); return *this; }
 
+            Desc& setShaderModel(const std::string& sm) { mBaseDesc.setShaderModel(sm); return *this; }
+
         private:
             friend class RtProgram;
 


### PR DESCRIPTION
This is needed in order to use DXR Tier 1.1 features such as `GeometryIndex()`, as that requires _Shader Model_ 6.5 while `RtProgram` defaults to _Shader Model_ 6.3.