### PR TITLE
GBufferRaster improvements

### DIFF
--- a/Source/RenderPasses/GBuffer/GBuffer/GBufferRaster.3d.slang
+++ b/Source/RenderPasses/GBuffer/GBuffer/GBufferRaster.3d.slang
@@ -39,6 +39,7 @@ RasterizerOrderedTexture2D<float2> gMotionVectors;
 RasterizerOrderedTexture2D<float4> gRoughness;
 RasterizerOrderedTexture2D<float4> gMetallic;
 RasterizerOrderedTexture2D<float4> gFaceNormalW;
+RasterizerOrderedTexture2D<float4> gViewW;
 RasterizerOrderedTexture2D<float2> gPosNormalFwidth;
 RasterizerOrderedTexture2D<float2> gLinearZAndDeriv;
 
@@ -103,6 +104,11 @@ GBufferPSOut psMain(VSOut vsOut, uint triangleIndex : SV_PrimitiveID, float3 bar
     if (is_valid(gFaceNormalW))
     {
         gFaceNormalW[ipos] = float4(sd.faceN, 0);
+    }
+
+    if (isValid(gViewW))
+    {
+        gViewW[ipos] = float4(sd.V, 0);
     }
 
     // Compute motion vectors.

--- a/Source/RenderPasses/GBuffer/GBuffer/GBufferRaster.cpp
+++ b/Source/RenderPasses/GBuffer/GBuffer/GBufferRaster.cpp
@@ -29,6 +29,8 @@
 #include "RenderGraph/RenderPassStandardFlags.h"
 #include "GBufferRaster.h"
 
+#include <limits>
+
 const char* GBufferRaster::kDesc = "Rasterized G-buffer generation pass";
 
 namespace
@@ -156,7 +158,10 @@ void GBufferRaster::execute(RenderContext* pRenderContext, const RenderData& ren
     auto clear = [&](const ChannelDesc& channel)
     {
         auto pTex = renderData[channel.name]->asTexture();
-        if (pTex) pRenderContext->clearUAV(pTex->getUAV().get(), float4(0.f));
+        if (pTex) {
+            if (channel.name == kVBufferName) pRenderContext->clearUAV(pTex->getUAV().get(), uint4(std::numeric_limits<uint32_t>::max()));
+            else pRenderContext->clearUAV(pTex->getUAV().get(), float4(0.f));
+        }
     };
     for (const auto& channel : kGBufferExtraChannels) clear(channel);
 

--- a/Source/RenderPasses/GBuffer/GBuffer/GBufferRaster.cpp
+++ b/Source/RenderPasses/GBuffer/GBuffer/GBufferRaster.cpp
@@ -49,6 +49,7 @@ namespace
         { "roughness",        "gRoughness",          "Roughness",                        true /* optional */, ResourceFormat::RGBA8Unorm  },
         { "metallic",         "gMetallic",           "Metallic",                         true /* optional */, ResourceFormat::RGBA8Unorm  },
         { "faceNormalW",      "gFaceNormalW",        "Face normal in world space",       true /* optional */, ResourceFormat::RGBA32Float },
+        { "viewW",            "gViewW",              "View direction in world space",    true /* optional */, ResourceFormat::RGBA32Float }, // TODO: Switch to packed 2x16-bit snorm format.
         { "pnFwidth",         "gPosNormalFwidth",    "position and normal filter width", true /* optional */, ResourceFormat::RG32Float   },
         { "linearZ",          "gLinearZAndDeriv",    "linear z (and derivative)",        true /* optional */, ResourceFormat::RG32Float   },
     };


### PR DESCRIPTION
* Its vbuffer output was not properly cleared, leading to all passes using it to think that every pixel had underlying geometry, even when in reality they did not.
* Add a new output, viewV, to allow using GBufferRaster in combination with MegakernelPathTracer with `useVBuffer=0`.