### PR TITLE
Disable warning C4819.

### DIFF
--- a/Source/Falcor/CMakeLists.txt
+++ b/Source/Falcor/CMakeLists.txt
@@ -852,6 +852,7 @@ target_compile_options(Falcor
         $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/W2>      # increase warning level
         $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/WX>      # warnings as errors
         $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/wd4251>  # 'type' : class 'type1' needs to have dll-interface to be used by clients of class 'type2'
+        $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/wd4819>  # The file contains a character that cannot be represented in the current code page (932)
         $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/MP>      # enable multi-processor compilation
         # Clang flags.
         $<$<CXX_COMPILER_ID:Clang>:-fms-extensions>     # enable MS extensions (among other things allow glm swizzle to work)


### PR DESCRIPTION
When Windows locale is Japanese, About these header files, Visual C++ treats C4819 as compile error. Because, when it happens that Visual C++ compiles UTF-8 files without BOM as cp932 encoding on Japanese locale. 

These header files are external, it modified is difficult, and future, more files may be. 

Files:
1.Falcor\external\packman\nanovdb\include\nanovdb\NanoVDB.h
2.Falcor\external\packman\deps\include\FreeImage.h

Error Messages (include Japanese):
Falcor\external\packman\nanovdb\include\nanovdb/NanoVDB.h(1,1): error C2220: 次の警告はエラーとして処理されます Falcor\external\packman\nanovdb\include\nanovdb/NanoVDB.h(1,1): warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。

Falcor\external\packman\deps\include\FreeImage.h(1,1): error C2220: 次の警告はエラーとして処理されます
Falcor\external\packman\deps\include\FreeImage.h(1,1): warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。

Every time Falcor has added a version, I have added C4819.
Probably all users in Japan have done so.

So, I make pull request that it disabled warning C4819 on VC Projects.

Best regards.