### PR TITLE
Fixing shadow flickering in a large scene like Bistro

### DIFF
--- a/Source/Falcor/Scene/Camera/Camera.cpp
+++ b/Source/Falcor/Scene/Camera/Camera.cpp
@@ -162,7 +162,8 @@ namespace Falcor
             mData.projMat = jitterMat * mData.projMat;
 
             mData.viewProjMat = mData.projMat * mData.viewMat;
-            mData.invViewProj = rmcv::inverse(mData.viewProjMat);
+            mData.invView = rmcv::inverse(mData.viewMat);
+            mData.invProj = rmcv::inverse(mData.projMat);
 
             // Extract camera space frustum planes from the VP matrix
             // See: https://fgiesen.wordpress.com/2012/08/31/frustum-planes-from-the-projection-matrix/
@@ -222,10 +223,16 @@ namespace Falcor
         return mData.viewProjMatNoJitter;
     }
 
-    const rmcv::mat4 Camera::getInvViewProjMatrix() const
+    const rmcv::mat4 Camera::getInvViewMatrix() const
     {
         calculateCameraParameters();
-        return mData.invViewProj;
+        return mData.invView;
+    }
+
+    const rmcv::mat4 Camera::getInvProjMatrix() const
+    {
+        calculateCameraParameters();
+        return mData.invProj;
     }
 
     void Camera::setProjectionMatrix(const rmcv::mat4& proj)

--- a/Source/Falcor/Scene/Camera/Camera.h
+++ b/Source/Falcor/Scene/Camera/Camera.h
@@ -227,9 +227,13 @@ namespace Falcor
         */
         const rmcv::mat4 getViewProjMatrixNoJitter() const;
 
-        /** Get the inverse of the view-projection matrix.
+        /** Get the inverse of the view matrix.
         */
-        const rmcv::mat4 getInvViewProjMatrix() const;
+        const rmcv::mat4 getInvViewMatrix() const;
+
+        /** Get the inverse of the projection matrix.
+        */
+        const rmcv::mat4 getInvProjMatrix() const;
 
         /** Set the persistent projection matrix and sets camera to use the persistent matrix instead of calculating the matrix from its other settings.
         */

--- a/Source/Falcor/Scene/Camera/Camera.slang
+++ b/Source/Falcor/Scene/Camera/Camera.slang
@@ -34,7 +34,8 @@ struct Camera
     CameraData data;
 
     float3 getPosition() { return data.posW; }
-    float4x4 getViewProj() { return data.viewProjMat; }
+    float4x4 getView() { return data.viewMat; }
+    float4x4 getProj() { return data.projMat; }
 
     /** Computes a camera ray for a given pixel assuming a pinhole camera model.
         The camera jitter is taken into account to compute the sample position on the image plane.

--- a/Source/Falcor/Scene/Camera/CameraData.slang
+++ b/Source/Falcor/Scene/Camera/CameraData.slang
@@ -38,7 +38,8 @@ struct CameraData
     float4x4 prevViewMat;               ///< Camera view matrix associated to previous frame.
     float4x4 projMat;                   ///< Camera projection matrix.
     float4x4 viewProjMat;               ///< Camera view-projection matrix.
-    float4x4 invViewProj;               ///< Camera inverse view-projection matrix.
+    float4x4 invView;                   ///< Camera inverse view matrix.
+    float4x4 invProj;                   ///< Camera inverse projection matrix.
     float4x4 viewProjMatNoJitter;       ///< Camera view-projection matrix. No jittering is applied!
     float4x4 prevViewProjMatNoJitter;   ///< Camera view-projection matrix associated to previous frame. No jittering is applied!
     float4x4 projMatNoJitter;           ///< Camera projection matrix. No jittering is applied!

--- a/Source/Falcor/Scene/Raster.slang
+++ b/Source/Falcor/Scene/Raster.slang
@@ -79,7 +79,7 @@ VSOut defaultVS(VSIn vIn)
     float4x4 worldMat = gScene.getWorldMatrix(instanceID);
     float3 posW = mul(worldMat, float4(vIn.pos, 1.f)).xyz;
     vOut.posW = posW;
-    vOut.posH = mul(gScene.camera.getViewProj(), float4(posW, 1.f));
+    vOut.posH = mul(gScene.camera.getProj(), mul(gScene.camera.getView(), float4(posW, 1.f)));
 
     vOut.instanceID = instanceID;
     vOut.materialID = gScene.getMaterialID(instanceID);

--- a/Source/RenderPasses/CSM/CSM.cpp
+++ b/Source/RenderPasses/CSM/CSM.cpp
@@ -337,8 +337,8 @@ void CSM::createShadowPassResources()
 
     RasterizerState::Desc rsDesc;
     rsDesc.setDepthClamp(true);
-    RasterizerState::SharedPtr rsState = RasterizerState::create(rsDesc);
-    mShadowPass.pState->setRasterizerState(rsState);
+    mShadowPass.pRsStateCW = RasterizerState::create(rsDesc.setFrontCounterCW(false).setCullMode(RasterizerState::CullMode::Back));
+    mShadowPass.pRsStateCCW = RasterizerState::create(rsDesc.setFrontCounterCW(true).setCullMode(RasterizerState::CullMode::Back));
 }
 
 CSM::CSM()
@@ -611,7 +611,14 @@ void CSM::renderScene(RenderContext* pCtx)
 
     pCB->setBlob(&mCsmData, 0, sizeof(mCsmData));
     mpLightCamera->setProjectionMatrix(mCsmData.globalMat);
-    mpScene->rasterize(pCtx, mShadowPass.pState.get(), mShadowPass.pVars.get());
+    if (mControls.depthClamp)
+    {
+        mpScene->rasterize(pCtx, mShadowPass.pState.get(), mShadowPass.pVars.get(), mShadowPass.pRsStateCW, mShadowPass.pRsStateCCW);
+    }
+    else
+    {
+        mpScene->rasterize(pCtx, mShadowPass.pState.get(), mShadowPass.pVars.get());
+    }
     //        mpCsmSceneRenderer->renderScene(pCtx, mShadowPass.pState.get(), mShadowPass.pVars.get(), mpLightCamera.get());
 }
 

--- a/Source/RenderPasses/CSM/CSM.h
+++ b/Source/RenderPasses/CSM/CSM.h
@@ -123,6 +123,8 @@ private:
         GraphicsProgram::SharedPtr pProgram;
         GraphicsVars::SharedPtr pVars;
         GraphicsState::SharedPtr pState;
+        RasterizerState::SharedPtr pRsStateCW;
+        RasterizerState::SharedPtr pRsStateCCW;
         float2 mapSize;
     } mShadowPass;
 

--- a/Source/RenderPasses/CSM/CSM.h
+++ b/Source/RenderPasses/CSM/CSM.h
@@ -175,7 +175,8 @@ private:
         // and remove this field.
         int3 padding;
 #endif
-        rmcv::mat4 camInvViewProj;
+        rmcv::mat4 camInvView;
+        rmcv::mat4 camInvProj;
         uint2 screenDim = { 0, 0 };
         uint32_t mapBitsPerChannel = 32;
     } mVisibilityPassData;

--- a/Source/RenderPasses/CSM/CSMData.slang
+++ b/Source/RenderPasses/CSM/CSMData.slang
@@ -45,7 +45,8 @@ struct CsmData
 {
     static const uint32_t kMaxCascades = 8;
 
-    float4x4 globalMat;
+    float4x4 shadowView;
+    float4x4 shadowProj;
     float4 cascadeScale[kMaxCascades];
     float4 cascadeOffset[kMaxCascades];
 

--- a/Source/RenderPasses/CSM/CascadedShadowMap.slang
+++ b/Source/RenderPasses/CSM/CascadedShadowMap.slang
@@ -239,7 +239,7 @@ float calcShadowFactorWithCascadeIdx(CsmData csmData, uint32_t cascadeIndex, flo
     //posW.xyz += calcNormalOffset(csmData, normal, cascadeIndex);
 
     // Get the global shadow space position
-    float4 shadowPos = mul(csmData.globalMat, float4(posW, 1));
+    float4 shadowPos = mul(csmData.shadowProj, mul(csmData.shadowView, float4(posW, 1)));
     shadowPos /= shadowPos.w;
 
     // Calculate the texC derivatives. We need to do that before applying the scale and offset - the cascadeIndex can be different for pixels in the same quad, resulting in wrong derivatives

--- a/Source/RenderPasses/CSM/DepthPass.slang
+++ b/Source/RenderPasses/CSM/DepthPass.slang
@@ -59,7 +59,7 @@ ShadowPassVSOut vsMain(VSIn vIn)
     float4x4 worldMat = gScene.getWorldMatrix(instanceID);
     vOut.pos = mul(worldMat, float4(vIn.pos, 1.f));
 #ifdef _APPLY_PROJECTION
-    vOut.pos = mul(gScene.camera.getViewProj(), vOut.pos);
+    vOut.pos = mul(gScene.camera.getProj(), mul(gScene.camera.getView(), vOut.pos));
 #endif
 
     vOut.texC = vIn.texC;

--- a/Source/RenderPasses/CSM/ShadowPass.slang
+++ b/Source/RenderPasses/CSM/ShadowPass.slang
@@ -67,7 +67,7 @@ ShadowPassVSOut vsMain(VSIn vIn)
     float4x4 worldMat = gScene.getWorldMatrix(instanceID);
     vOut.pos = mul(worldMat, float4(vIn.pos, 1.f));
 #ifdef _APPLY_PROJECTION
-    vOut.pos = mul(gScene.camera.getViewProj(), vOut.pos);
+    vOut.pos = mul(gScene.camera.getProj(), mul(gScene.camera.getView(), vOut.pos));
 #endif
 
     vOut.texC = vIn.texC;
@@ -86,7 +86,7 @@ void gsMain(triangle ShadowPassVSOut input[3], uint InstanceID : SV_GSInstanceID
 
     for(int i = 0 ; i < 3 ; i++)
     {
-        outputData.pos = mul(gCsmData.globalMat, input[i].pos);
+        outputData.pos = mul(gCsmData.shadowProj, mul(gCsmData.shadowView, input[i].pos));
         outputData.pos.xyz /= input[i].pos.w;
         outputData.pos.xyz *= gCsmData.cascadeScale[InstanceID].xyz;
         outputData.pos.xyz += gCsmData.cascadeOffset[InstanceID].xyz;

--- a/Source/RenderPasses/CSM/VisibilityPass.ps.slang
+++ b/Source/RenderPasses/CSM/VisibilityPass.ps.slang
@@ -30,7 +30,8 @@ import RenderPasses.CSM.CascadedShadowMap;
 struct VisibilityPassData
 {
     bool visualizeCascades;
-    float4x4 invViewProj;
+    float4x4 invView;
+    float4x4 invProj;
     uint2 screenDimension;
     uint mapBitsPerChannel;
 };
@@ -52,7 +53,7 @@ float3 loadPosition(float2 UV, float depth)
     // NDC Y is bottom-to-top
     ndc.y = -ndc.y;
 #endif
-    float4 wsPos = mul(gPass.invViewProj, float4(ndc.x, ndc.y, depth, 1.f));
+    float4 wsPos = mul(gPass.invView, mul(gPass.invProj, float4(ndc.x, ndc.y, depth, 1.f)));
     return wsPos.xyz / wsPos.w;
 }
 

--- a/Source/RenderPasses/SSAO/SSAO.ps.slang
+++ b/Source/RenderPasses/SSAO/SSAO.ps.slang
@@ -59,7 +59,7 @@ float4 getPosition(float2 uv)
     pos.z = gDepthTex.SampleLevel(gTextureSampler, uv, 0).r;
     pos.w = 1.0f;
 
-    float4 posW = mul(gCamera.data.invViewProj, pos);
+    float4 posW = mul(gCamera.data.invView, mul(gCamera.data.invProj, pos));
     posW /= posW.w;
 
     return posW;
@@ -93,7 +93,7 @@ float4 main(float2 texC : TEXCOORD) : SV_TARGET0
         float sampleDepth = length(samplePosW - gCamera.data.posW);
 
         // Get screen space pos of sample
-        float4 samplePosProj = mul(gCamera.data.viewProjMat, float4(samplePosW, 1.0f));
+        float4 samplePosProj = mul(gCamera.data.projMat, mul(gCamera.data.viewMat, float4(samplePosW, 1.0f)));
         samplePosProj /= samplePosProj.w;
 
         // Sample depth buffer at the same place as sample


### PR DESCRIPTION
I made a fix the flickering shadow issue mentioned in https://github.com/NVIDIAGameWorks/Falcor/issues/277 and https://github.com/NVIDIAGameWorks/Falcor/issues/324 .

Stock Falcor ForwardRenderer.py output of my branch using Bistro scene.

![Mogwai exe 0](https://user-images.githubusercontent.com/1116327/196259564-6f6f18e9-976f-4b68-8e6e-357957542e0a.png)

https://youtu.be/m8YPUF3erQs

This PR consists of three parts; 

- fixed degraded depth clamping issue (https://github.com/NVIDIAGameWorks/Falcor/pull/269/files) in CSM
- stopped using pre-calculated invViewProj matrix to avoid precision error
- separate view and projection matrix in Raster, CSM, SSAO passes

Falcor shadow pass (CSM) works pretty well with small scenes like Arcade but causes shadow flickering in a large scene like Bistro for a long time.

The root cause seems to lie around the float-point precision error of the view matrix (large value in a large scene) and projection matrix (relatively small values) multiplication.

Although you may see some artifacts like shadow acne, that would be mitigated with tuning shadow bias or normal offset (currently commented out in the CSM pass).
