### PR TITLE
Fix out-of-date tutorials

### DIFF
--- a/docs/tutorials/01-mogwai-usage.md
+++ b/docs/tutorials/01-mogwai-usage.md
@@ -53,7 +53,7 @@ If you start it without specifying any options, Mogwai starts with a blank scree
 With Mogwai up and running, we'll proceed to loading something. You can load two kinds of files: scripts (which usually contain some global settings and render graphs) and scenes.
 
 ### Loading a Script (.py)
-Open the load script dialog by either going to `File -> Load Script` or hitting `Ctrl + O`. Navigate to the location of the script you wish to run and select it to load and run it. Alternatively, dragging-and-dropping a script into Mogwai will also work. Note that scripts intended for use with Mogwai must be written in Python. Full scripting documentation can be found [here](../Usage/Scripting.md).
+Open the load script dialog by either going to `File -> Load Script` or hitting `Ctrl + O`. Navigate to the location of the script you wish to run and select it to load and run it. Alternatively, dragging-and-dropping a script into Mogwai will also work. Note that scripts intended for use with Mogwai must be written in Python. Full scripting documentation can be found [here](../usage/scripting.md).
 
 Here, we'll load the Forward Renderer, located at `Source/Mogwai/Data/ForwardRenderer.py`.
 

--- a/docs/tutorials/01-mogwai-usage.md
+++ b/docs/tutorials/01-mogwai-usage.md
@@ -24,6 +24,7 @@ Run Mogwai from within Visual Studio (by pressing Ctrl+F5), or from the command 
 
       -h, --help                        Display this help menu.
       -s[path], --script=[path]         Python script file to run.
+      --deferred                        The script is loaded deferred.
       -S[path], --scene=[path]          Scene file (for example, a .pyscene
                                         file) to open.
       -l[path], --logfile=[path]        File to write log into.
@@ -42,6 +43,8 @@ Run Mogwai from within Visual Studio (by pressing Ctrl+F5), or from the command 
       -d, --debug-shaders               Generate shader debug info.
       --enable-debug-layer              Enable debug layer (enabled by default
                                         in Debug build).
+      --precise                         Force all slang programs to run in
+                                        precise mode
 ```
 
 Using `--silent` together with `--script` allows to run Mogwai for rendering in the background.

--- a/docs/tutorials/02-implementing-a-render-pass.md
+++ b/docs/tutorials/02-implementing-a-render-pass.md
@@ -82,4 +82,4 @@ You can adjust the description of the render pass library by adjusting the follo
 const RenderPass::Info ExampleBlitPass::kInfo { "ExampleBlitPass", "Blits a texture into another texture." };
 ```
 
-We will ignore further details regarding render passes and their implementation for the purposes of this tutorial. Additional information can be found [here](../Usage/Render-Passes.md).
+We will ignore further details regarding render passes and their implementation for the purposes of this tutorial. Additional information can be found [here](../usage/render-passes.md).

--- a/docs/tutorials/03-creating-and-editing-render-graphs.md
+++ b/docs/tutorials/03-creating-and-editing-render-graphs.md
@@ -61,7 +61,7 @@ Creating a render graph through scripting follows similar steps as creating it t
     - `markOutput()` takes an optional `mask` parameter specifying which color channels to output for frame capture.
     - Multiple calls to `markOutput()` with different masks can be made, frame capture will generate separate output files.
 
-*For more information on the scripting API, you can find the documentation [here](../Usage/Scripting.md).*
+*For more information on the scripting API, you can find the documentation [here](../usage/scripting.md).*
 
 To create a render graph through scripting:
 1. Create a function to contain the commands. This is not required, but recommended.

--- a/docs/tutorials/04-writing-shaders.md
+++ b/docs/tutorials/04-writing-shaders.md
@@ -67,7 +67,7 @@ WireframePass::WireframePass() : RenderPass(kInfo)
     mpGraphicsState->setRasterizerState(mpRasterState);
 }
 ```
-## `reflect()`
+### `reflect()`
 As in the Implementing a Render Pass tutorial, you simply set the Output for the Wireframe view.
 ```c++
 RenderPassReflection WireframePass::reflect(const CompileData& compileData)

--- a/docs/tutorials/04-writing-shaders.md
+++ b/docs/tutorials/04-writing-shaders.md
@@ -66,6 +66,16 @@ WireframePass::WireframePass() : RenderPass(kInfo) {
     mpGraphicsState->setRasterizerState(mpRasterState);
 }
 ```
+## `reflect()`
+As in the Implementing a Render Pass tutorial, you simply set the Output for the Wireframe view.
+```
+RenderPassReflection WireframePass::reflect(const CompileData &compileData)
+{
+    RenderPassReflection reflector;
+    reflector.addOutput("output", "Wireframe view texture");
+    return reflector;
+}
+```
 
 ### `setScene()`
 Our first render pass had no need for a `Scene` object; however, this pass does and will need this function to set `mpScene`. We first need to set `mpScene` to the scene that's passed in then add all scene defines to `mpProgram`. We then create our `GraphicsVars` so that we can bind shader variables later in `execute()`. These are done like so:
@@ -110,9 +120,7 @@ void WireframePass::execute(RenderContext *pRenderContext, const RenderData &ren
     const float4 clearColor(0, 0, 0, 1);
     pRenderContext->clearFbo(pTargetFbo.get(), clearColor, 1.0f, 0, FboAttachmentType::All);
     mpGraphicsState->setFbo(pTargetFbo);
-    mpGraphicsState->setDepthStencilState(mpNoDepthDS);
     if (mpScene) {
-        // Set render state
         mpVars["PerFrameCB"]["gColor"] = float4(0, 1, 0, 1);
 
         mpScene->rasterize(pRenderContext, mpGraphicsState.get(), mpVars.get(), mpRasterState, mpRasterState);
@@ -122,16 +130,16 @@ void WireframePass::execute(RenderContext *pRenderContext, const RenderData &ren
 
 And you need to create CMakeLists.txt to include your C++ and Slang files in the build target.
 ```CMake
-add_renderpass(Wireframe)
+add_renderpass(WireframePass)
 
-target_sources(Wireframe PRIVATE
-        WireframePass.cpp
-        WireframePass.h
-        WireframePass.3d.slang
-        )
-target_copy_shaders(Wireframe RenderPasses/Wireframe)
+target_sources(WireframePass PRIVATE
+    WireframePass.cpp
+    WireframePass.h
+    WireframePass.3d.slang
+)
+target_copy_shaders(WireframePass RenderPasses/WireframePass)
 
-target_source_group(Wireframe "RenderPasses")
+target_source_group(WireframePass "RenderPasses")
 ```
 
 

--- a/docs/tutorials/04-writing-shaders.md
+++ b/docs/tutorials/04-writing-shaders.md
@@ -4,7 +4,7 @@
 
 # Writing Shaders
 
-Now that we've written a basic render pass and render graph, let's look at writing more complex passes that use shaders. Falcor uses the Slang shading language and compiler, and files should use one of the following extensions: `.slang`, `.slangh`, `.hlsl`, `.hlsli`. For more information on best practices for working with shaders in Falcor, please refer to the *Using Shaders and Data Files* section of the [Getting Started](../Getting-Started.md) page.
+Now that we've written a basic render pass and render graph, let's look at writing more complex passes that use shaders. Falcor uses the Slang shading language and compiler, and files should use one of the following extensions: `.slang`, `.slangh`, `.hlsl`, `.hlsli`. For more information on best practices for working with shaders in Falcor, please refer to the *Using Shaders and Data Files* section of the [Getting Started](../getting-started.md) page.
 
 For this tutorial, we'll create a pass that renders a scene as a wireframe of a particular color.
 
@@ -53,10 +53,9 @@ While `create()` does not need to do more than calling the constructor and retur
 
 The constructor should look similar to this:
 ```c++
-WireframePass::WireframePass()
-{
-    mpProgram = GraphicsProgram::createFromFile("RenderPasses/WireframePass/Wireframe.3d.slang", "vsMain", "psMain");
-
+WireframePass::WireframePass() : RenderPass(kInfo) {
+    mpProgram = GraphicsProgram::createFromFile("RenderPasses/Wireframe/Wireframe.3d.slang", "vsMain",
+                                                "psMain");
     RasterizerState::Desc wireframeDesc;
     wireframeDesc.setFillMode(RasterizerState::FillMode::Wireframe);
     wireframeDesc.setCullMode(RasterizerState::CullMode::None);
@@ -93,38 +92,66 @@ pRenderContext->clearFbo(pTargetFbo.get(), clearColor, 1.0f, 0, FboAttachmentTyp
 mpGraphicsState->setFbo(pTargetFbo);
 ```
 
-#### Setting the Render State
-We need to perform two operations here: indicate that we want to use a custom `RasterizerState` and bind all necessary values to our shader. We can indicate that we're using a custom `RasterizerState` by creating a `Scene::Renderflags` object and setting the flag `Scene::RenderFlags::UserRasterizerState`. Binding shader values is also fairly straightforward as Falcor allows you to set shader values in the `GraphicsVars` object in the same way as you would set values in an array. Our shader requires a single color value, `gColor`, which is located inside the `perFrameCB` constant buffer. This step should look like this:
+#### Binding the shader
+Binding shader values is also fairly straightforward as Falcor allows you to set shader values in the `GraphicsVars` object in the same way as you would set values in an array. Our shader requires a single color value, `gColor`, which is located inside the `perFrameCB` constant buffer. This step should look like this:
 ```c++
-Scene::RenderFlags renderFlags = Scene::RenderFlags::UserRasterizerState;
 mpVars["perFrameCB"]["gColor"] = float4(0, 1, 0, 1);
 ```
 
 #### Rendering a Scene Using the Shader
 With our scene, shader, and both the `GraphicsState` and `RasterizerState` set up, we can finally render our scene at the end of `execute()`. This is done through the `render()` method of `mpScene`, like so:
 ```c++
-mpScene->rasterize(pRenderContext, mpGraphicsState.get(), mpGraphicsVars.get(), renderFlags);
+mpScene->rasterize(pRenderContext, mpGraphicsState.get(), mpVars.get(), mpRasterState, mpRasterState);
 ```
 Your `execute()` function should now look like this, with a check for `mpScene` so we avoid accessing the scene when it isn't set:
 ```c++
-void WireframePass::execute(RenderContext* pRenderContext, const RenderData& renderData)
-{
-    auto pTargetFbo = Fbo::create({ renderData.getTexture("output") });
+void WireframePass::execute(RenderContext *pRenderContext, const RenderData &renderData) {
+    auto pTargetFbo = Fbo::create({renderData.getTexture("output")});
     const float4 clearColor(0, 0, 0, 1);
     pRenderContext->clearFbo(pTargetFbo.get(), clearColor, 1.0f, 0, FboAttachmentType::All);
     mpGraphicsState->setFbo(pTargetFbo);
-
-    if (mpScene)
-    {
+    mpGraphicsState->setDepthStencilState(mpNoDepthDS);
+    if (mpScene) {
         // Set render state
-        Scene::RenderFlags renderFlags = Scene::RenderFlags::UserRasterizerState;
         mpVars["PerFrameCB"]["gColor"] = float4(0, 1, 0, 1);
 
-        mpScene->rasterize(pRenderContext, mpGraphicsState.get(), mpVars.get(), renderFlags);
+        mpScene->rasterize(pRenderContext, mpGraphicsState.get(), mpVars.get(), mpRasterState, mpRasterState);
     }
 }
 ```
 
-Using the Render Graph Editor, create a graph solely containing this pass then launch it in Mogwai. You should see a black screen as there is no scene currently loaded. Load a scene by going to `File -> Load Scene`, and you should now see the wireframe for the scene you selected. We used `media/Arcade/Arcade.pyscene`, which looks like this:
+And you need to create CMakeLists.txt to include your C++ and Slang files in the build target.
+```CMake
+add_renderpass(Wireframe)
+
+target_sources(Wireframe PRIVATE
+        WireframePass.cpp
+        WireframePass.h
+        WireframePass.3d.slang
+        )
+target_copy_shaders(Wireframe RenderPasses/Wireframe)
+
+target_source_group(Wireframe "RenderPasses")
+```
+
+
+Using the Render Graph Editor, create a graph solely containing this pass then launch it in Mogwai, or create a python script.
+```python
+from falcor import *
+
+def render_graph_WireframePass():
+    g = RenderGraph('WireframePass')
+    loadRenderPassLibrary('WireframePass.dll')
+    Wireframe = createPass('WireframePass')
+    g.addPass(WireframePass, 'WireframePass')
+    g.markOutput('WireframePass.output')
+    return g
+
+WireframePass = render_graph_WireframePass()
+try: m.addGraph(WireframePass)
+except NameError: None
+```
+
+ You should see a green screen as there is no scene currently loaded. Load a scene by going to `File -> Load Scene`, and you should now see the wireframe for the scene you selected. We used `media/Arcade/Arcade.pyscene`, which looks like this:
 
 ![WireframePass](./images/wireframe-pass.png)

--- a/docs/tutorials/04-writing-shaders.md
+++ b/docs/tutorials/04-writing-shaders.md
@@ -104,9 +104,9 @@ mpGraphicsState->setFbo(pTargetFbo);
 ```
 
 #### Binding the shader
-Binding shader values is also fairly straightforward as Falcor allows you to set shader values in the `GraphicsVars` object in the same way as you would set values in an array. Our shader requires a single color value, `gColor`, which is located inside the `perFrameCB` constant buffer. This step should look like this:
+Binding shader values is also fairly straightforward as Falcor allows you to set shader values in the `GraphicsVars` object in the same way as you would set values in a dictionary. Our shader requires a single color value, `gColor`, which is located inside the `PerFrameCB` constant buffer. This step should look like this:
 ```c++
-mpVars["perFrameCB"]["gColor"] = float4(0, 1, 0, 1);
+mpVars["PerFrameCB"]["gColor"] = float4(0, 1, 0, 1);
 ```
 
 #### Rendering a Scene Using the Shader

--- a/docs/tutorials/04-writing-shaders.md
+++ b/docs/tutorials/04-writing-shaders.md
@@ -53,7 +53,8 @@ While `create()` does not need to do more than calling the constructor and retur
 
 The constructor should look similar to this:
 ```c++
-WireframePass::WireframePass() : RenderPass(kInfo) {
+WireframePass::WireframePass() : RenderPass(kInfo)
+{
     mpProgram = GraphicsProgram::createFromFile("RenderPasses/Wireframe/Wireframe.3d.slang", "vsMain",
                                                 "psMain");
     RasterizerState::Desc wireframeDesc;
@@ -68,8 +69,8 @@ WireframePass::WireframePass() : RenderPass(kInfo) {
 ```
 ## `reflect()`
 As in the Implementing a Render Pass tutorial, you simply set the Output for the Wireframe view.
-```
-RenderPassReflection WireframePass::reflect(const CompileData &compileData)
+```c++
+RenderPassReflection WireframePass::reflect(const CompileData& compileData)
 {
     RenderPassReflection reflector;
     reflector.addOutput("output", "Wireframe view texture");
@@ -115,12 +116,14 @@ mpScene->rasterize(pRenderContext, mpGraphicsState.get(), mpVars.get(), mpRaster
 ```
 Your `execute()` function should now look like this, with a check for `mpScene` so we avoid accessing the scene when it isn't set:
 ```c++
-void WireframePass::execute(RenderContext *pRenderContext, const RenderData &renderData) {
+void WireframePass::execute(RenderContext* pRenderContext, const RenderData& renderData)
+{
     auto pTargetFbo = Fbo::create({renderData.getTexture("output")});
     const float4 clearColor(0, 0, 0, 1);
     pRenderContext->clearFbo(pTargetFbo.get(), clearColor, 1.0f, 0, FboAttachmentType::All);
     mpGraphicsState->setFbo(pTargetFbo);
-    if (mpScene) {
+    if (mpScene)
+    {
         mpVars["PerFrameCB"]["gColor"] = float4(0, 1, 0, 1);
 
         mpScene->rasterize(pRenderContext, mpGraphicsState.get(), mpVars.get(), mpRasterState, mpRasterState);


### PR DESCRIPTION
This relates to the following [issue](https://github.com/NVIDIAGameWorks/Falcor/issues/335)
The links to other documentation included in the tutorial and the `Scene::Renderflags` in the writing-shaders tutorial are outdated.
Many people have probably already noticed this, but no one seems to have fixed it.
It works with Version 5.2.