### PR TITLE
fix mouse input crash in release mode (#342)

### DIFF
--- a/Source/Falcor/Core/Window.cpp
+++ b/Source/Falcor/Core/Window.cpp
@@ -117,7 +117,7 @@ public:
             break;
         default:
             // Other keys are not supported
-            break;
+            return;
         }
 
         Window* pWindow = (Window*)glfwGetWindowUserPointer(pGlfwWindow);


### PR DESCRIPTION
changed the break to a return so the unsupported button press won't get processed