### PR TITLE
added gli library for dds export

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "external/vulkan-headers"]
 	path = external/vulkan-headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers
+[submodule "external/gli"]
+	path = external/gli
+	url = https://github.com/g-truc/gli.git

--- a/Source/Falcor/CMakeLists.txt
+++ b/Source/Falcor/CMakeLists.txt
@@ -850,7 +850,7 @@ target_link_libraries(Falcor
     PRIVATE
         git_version
         FreeImage assimp ffmpeg OpenEXR OpenVDB lz4 zlib pugixml
-        glfw mikktspace nvtt
+        gli glfw mikktspace nvtt
         $<$<BOOL:${FALCOR_HAS_D3D12}>:d3d12>
         $<$<BOOL:${FALCOR_HAS_D3D12_AGILITY_SDK}>:agility-sdk>
         $<$<BOOL:${FALCOR_HAS_NVAPI}>:nvapi>

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -41,6 +41,11 @@ add_subdirectory(glfw)
 message(STATUS "Configure glm")
 add_subdirectory(glm)
 
+# gli
+message(STATUS "Configure gli")
+set(GLI_TEST_ENABLE OFF)
+add_subdirectory(gli)
+
 # imgui
 add_library(imgui INTERFACE)
 target_include_directories(imgui INTERFACE imgui)


### PR DESCRIPTION
I added the gtruc/gli as submodule and implemented the DDS export in the Texture class.
This works with any 2D texture DDS files, including texture 2D arrays and integer formats.

The only problem is, that the cmake generates a gli_dummy project in the root. I do not know how to move this to a sub folder because I'm not too experienced with cmake.