### PR TITLE
 Update the number and names of nodes in the Graph UI.

### DIFF
--- a/Source/Falcor/RenderGraph/RenderGraphUI.cpp
+++ b/Source/Falcor/RenderGraph/RenderGraphUI.cpp
@@ -1066,7 +1066,8 @@ namespace Falcor
             RenderPass* pNodeRenderPass = mpRenderGraph->getPass(currentPass.first).get();
             nameString = currentPass.first;
 
-            if (!mpNodeGraphEditor->getAllNodesOfType(currentPassUI.mGuiNodeID, nullptr, false))
+            ImVector<ImGui::Node*> nodesOut;
+            if (!mpNodeGraphEditor->getAllNodesOfType(currentPassUI.mGuiNodeID, &nodesOut, false))
             {
                 float2 nextPosition = mAddedFromDragAndDrop ? mNewNodeStartPosition : getNextNodePosition(mpRenderGraph->getPassIndex(nameString));
 
@@ -1074,6 +1075,13 @@ namespace Falcor
                     nameString, outputsString, inputsString, guiNodeID, pNodeRenderPass,
                     ImVec2(nextPosition.x, nextPosition.y));
                 mAddedFromDragAndDrop = false;
+            }
+            else
+            {
+                for (auto& node : nodesOut)
+                {
+                    node->updateSlotNames(inputsString.c_str(), outputsString.c_str());
+                }
             }
         }
 

--- a/external/imgui_addons/imguinodegrapheditor/imguinodegrapheditor.cpp
+++ b/external/imgui_addons/imguinodegrapheditor/imguinodegrapheditor.cpp
@@ -1975,6 +1975,11 @@ namespace ImGui {
         isOpen = true;
     }
 
+    IMGUI_API void Node::updateSlotNames(const char* inputSlotNamesSeparatedBySemicolons, const char* outputSlotNamesSeparatedBySemicolons) {
+        InputsCount = ProcessSlotNamesSeparatedBySemicolons<IMGUINODE_MAX_INPUT_SLOTS>(inputSlotNamesSeparatedBySemicolons, InputNames);
+        OutputsCount = ProcessSlotNamesSeparatedBySemicolons<IMGUINODE_MAX_OUTPUT_SLOTS>(outputSlotNamesSeparatedBySemicolons, OutputNames);
+    }
+
     /*
     bool FieldInfo::copyFrom(const FieldInfo &f) {
         if (!isCompatibleWith(f)) return false;

--- a/external/imgui_addons/imguinodegrapheditor/imguinodegrapheditor.h
+++ b/external/imgui_addons/imguinodegrapheditor/imguinodegrapheditor.h
@@ -268,6 +268,7 @@ namespace ImGui {
         inline int getNumInputSlots() const { return InputsCount; }
         inline int getNumOutputSlots() const { return OutputsCount; }
         inline void setOpen(bool flag) { isOpen = flag; }
+        IMGUI_API void updateSlotNames(const char* inputSlotNamesSeparatedBySemicolons = NULL, const char* outputSlotNamesSeparatedBySemicolons = NULL);
 
     protected:
         FieldInfoVector fields; // I guess you can just skip these at all and implement virtual methods... but it was supposed to be useful...


### PR DESCRIPTION
After updating the number and names of nodes in the Graph UI via reflect in pass, the pop-up that appears when hovering the mouse over the nodes reflects the changes, but the pass node in the Graph UI itself does not update the node count and names. This PR fixes this issue.