### PR TITLE
Fix mvec calculation of dynamic geometry

### DIFF
--- a/Source/Falcor/Scene/Raster.slang
+++ b/Source/Falcor/Scene/Raster.slang
@@ -94,7 +94,7 @@ VSOut defaultVS(VSIn vIn)
     GeometryInstanceData instance = gScene.getGeometryInstance(instanceID);
     if (instance.isDynamic())
     {
-        uint prevVertexIndex = gScene.meshes[instance.geometryIndex].prevVbOffset + vIn.vertexID;
+        uint prevVertexIndex = gScene.meshes[instance.geometryID].prevVbOffset + vIn.vertexID;
         prevPos = gScene.prevVertices[prevVertexIndex].position;
     }
     float3 prevPosW = mul(gScene.getPrevWorldMatrix(instanceID), float4(prevPos, 1.f)).xyz;


### PR DESCRIPTION
The typo introduces incorrect prevPos for dynamic object. It leads to incorrect mvec in GBufferRaster. 
Similar calculation in GBufferRT is here, which is correct.
https://github.com/NVIDIAGameWorks/Falcor/blob/8526e89f0db9fb7a2704c4a6c00efa038e0c9d78/Source/Falcor/Scene/Scene.slang#L622