### PR TITLE
Disable warning C4819.

### DIFF
--- a/Source/Falcor/CMakeLists.txt
+++ b/Source/Falcor/CMakeLists.txt
@@ -821,6 +821,7 @@ target_compile_options(Falcor
             /WX                             # warnings as errors
             /W4                             # increase warning level
             /wd4251                         # 'type' : class 'type1' needs to have dll-interface to be used by clients of class 'type2'
+            /wd4819                         # The file contains a character that cannot be represented in the current code page(936)             
             /wd4244                         # 'conversion' conversion from 'type1' to 'type2', possible loss of data
             /wd4267                         # 'var' : conversion from 'size_t' to 'type', possible loss of data
             /wd4100                         # unreferenced formal parameter


### PR DESCRIPTION
I encountered the same compile error, C4819, as #326 did when Windows locate is Chinese. Although his commit was merged previously, it seems to have been discarded in a later update. Therefore, I believe I should submit this pull request.
Best regards.