### PR TITLE
Bugfix: locale float to_string

### DIFF
--- a/Source/Falcor/Scene/Scene.cpp
+++ b/Source/Falcor/Scene/Scene.cpp
@@ -288,7 +288,7 @@ namespace Falcor
         defines.add(getSceneSDFGridDefines());
 
         // The following defines may change at runtime.
-        defines.add("SCENE_DIFFUSE_ALBEDO_MULTIPLIER", std::to_string(mRenderSettings.diffuseAlbedoMultiplier));
+        defines.add("SCENE_DIFFUSE_ALBEDO_MULTIPLIER", fmt::format("{:f}", mRenderSettings.diffuseAlbedoMultiplier));
         defines.add("SCENE_GEOMETRY_TYPES", std::to_string((uint32_t)mGeometryTypes));
 
         defines.add(mpMaterials->getDefines());

--- a/Source/RenderPasses/PathTracer/PathTracer.cpp
+++ b/Source/RenderPasses/PathTracer/PathTracer.cpp
@@ -1406,7 +1406,7 @@ DefineList PathTracer::StaticParams::getDefines(const PathTracer& owner) const
     defines.add("USE_SER", useSER ? "1" : "0");
     defines.add("COLOR_FORMAT", std::to_string((uint32_t)colorFormat));
     defines.add("MIS_HEURISTIC", std::to_string((uint32_t)misHeuristic));
-    defines.add("MIS_POWER_EXPONENT", std::to_string(misPowerExponent));
+    defines.add("MIS_POWER_EXPONENT", fmt::format("{:f}", misPowerExponent));
 
     // Sampling utilities configuration.
     FALCOR_ASSERT(owner.mpSampleGenerator);


### PR DESCRIPTION
This is fixes a bug that leads to a compile error when the local system uses a comma (",") instead of dot (".") as decimal-point (e.g., in German).

Scene.cpp:
`defines.add("SCENE_DIFFUSE_ALBEDO_MULTIPLIER", std::to_string(mRenderSettings.diffuseAlbedoMultiplier));`

StandardMaterial.slang:
`d.diffuse = saturate(d.diffuse * SCENE_DIFFUSE_ALBEDO_MULTIPLIER);`


Example:
`std::cout << std::to_string(mRenderSettings.diffuseAlbedoMultiplier) << " vs. " << fmt::format("{:f}", RenderSettings.diffuseAlbedoMultiplier) << std::endl;`

Output:
`1,000000 vs. 1.000000`