### PR TITLE
match code with paper weight_i computation

### DIFF
--- a/Source/RenderPasses/WARDiffPathTracer/WarpedAreaReparam.slang
+++ b/Source/RenderPasses/WARDiffPathTracer/WarpedAreaReparam.slang
@@ -61,11 +61,15 @@ float computeHarmonicWeight(
     float boundaryTerm = no_diff computeBoundaryTerm(isect.normalW, auxDirection);
 
     float sy = max(1.f - auxSampleY, 1e-6f);
-    float invVMFDensity = 1.f / ((1.f - sy) * exp(-2.f * kappa) + sy);
+    // see WAS paper Algorithm 2, computation of weight_i
+    /* float invVMFDensity = 1.f / ((1.f - sy) * exp(-2.f * kappa) + sy);
 
     float wDenom = invVMFDensity - 1.f + boundaryTerm;
     float wDenomRcp = select(wDenom > 1e-4f, 1.f / wDenom, 0.f);
-    float w = wDenomRcp * wDenomRcp * wDenomRcp * invVMFDensity;
+    float w = wDenomRcp * wDenomRcp * wDenomRcp * invVMFDensity; */
+
+    float VMFDensity = (1.f - sy) * exp(-2.f * kappa) + sy;
+    float w = 1.f / (VMFDensity - 1.f + boundaryTerm) / VMFDensity;
     return w;
 }
 
@@ -80,6 +84,7 @@ DifferentialPair<float> fwd_computeHarmonicWeight(
     DifferentialPair<float3> direction
 )
 {
+    // TODO: how to change accordingly in the fwd pass
     float boundaryTerm = no_diff computeBoundaryTerm(isect.normalW, auxDirection);
 
     float sy = max(1.f - auxSampleY, 1e-6f);

--- a/Source/RenderPasses/WARDiffPathTracer/WarpedAreaReparam.slang
+++ b/Source/RenderPasses/WARDiffPathTracer/WarpedAreaReparam.slang
@@ -48,7 +48,7 @@ float computeBoundaryTerm(float3 normalW, float3 direction)
 
 [Differentiable]
 [PreferRecompute]
-[ForwardDerivative(fwd_computeHarmonicWeight)]
+// [ForwardDerivative(fwd_computeHarmonicWeight)]
 float computeHarmonicWeight(
     no_diff IntersectionAD isect,
     no_diff float3 origin,
@@ -58,19 +58,36 @@ float computeHarmonicWeight(
     float3 direction
 )
 {
-    float boundaryTerm = no_diff computeBoundaryTerm(isect.normalW, auxDirection);
+    // find boundary Term B; no_diff
+    float B = no_diff computeBoundaryTerm(isect.normalW, auxDirection);
 
-    float sy = max(1.f - auxSampleY, 1e-6f);
-    // see WAS paper Algorithm 2, computation of weight_i
-    /* float invVMFDensity = 1.f / ((1.f - sy) * exp(-2.f * kappa) + sy);
+    // Computation of weight_i, see WAS paper Algorithm 2,
+    /// Don't know why sampleVonMisesFisher() maps uv.v to 1-uv.v, but need consistency
+    float sy = 1.f - auxSampleY;
 
-    float wDenom = invVMFDensity - 1.f + boundaryTerm;
-    float wDenomRcp = select(wDenom > 1e-4f, 1.f / wDenom, 0.f);
-    float w = wDenomRcp * wDenomRcp * wDenomRcp * invVMFDensity; */
+    /* // full derivation
+    // NUMERICAL ISSUE: kappa is very large, must avoid exp(kappa) or similar expression
+    //    see 2. Evaluations, https://www.mitsuba-renderer.org/~wenzel/files/vmf.pdf
+    /// step 0: compute dot(w, w') = cos(theta) locally = mu^T * x in Wikipedia notation
+    float cosTheta = 1.f + log(exp(-2.f * kappa) * (1.f - sy) + sy) / kappa;
+    /// step 1: compute exp(kappa * [cos(theta) - 1]): move a exp(kappa) from normC to the exp term
+    float expTerm = exp(kappa * (1.f - cosTheta));
+    /// step 2: compute pdf(w_i)
+    /// see Definition, https://en.wikipedia.org/w/index.php?title=Von_Mises%E2%80%93Fisher_distribution
+    /// observe that the exp() part in pdf is exactly 1/expTerm computed above
+    float normC = kappa * M_1_2PI / (1.f - exp(-2.f * kappa));
+    float pdfVMFinv = expTerm / normC;
+    /// step 3: compute denominator exp(kappa - kappa * cos(theta)) - 1 + B
+    float denom = expTerm - 1.f + B; */
 
-    float VMFDensity = (1.f - sy) * exp(-2.f * kappa) + sy;
-    float w = 1.f / (VMFDensity - 1.f + boundaryTerm) / VMFDensity;
-    return w;
+    // concise version
+    /// key is expand cosTheta in the expTerm. Have a lot to cancel.
+    float expTerm = (1.f - sy) * exp(-2.f * kappa) + sy;
+    float pdfVMFinv =  M_2PI  * (1.f - exp(-2.f * kappa)) * expTerm / kappa;
+    float denom = expTerm - 1.f + B;
+
+    // w = 1 / denom / pdf
+    return pdfVMFinv / denom;
 }
 
 [Differentiable]


### PR DESCRIPTION
Originally brought up in issue #426 created earlier

Here is the copied info:
*****************************************************************************

This may be long and a little involved. I will try my best to explain the possible issue.

It's an issue of implementation detail of harmonic weight used by warped-area sampling (WAS) differentiable path tracer. Here is the [paper](http://people.csail.mit.edu/sbangaru/projects/was-2020/was-2020.pdf)

I am talking about this function: float computeHarmonicWeight() in Source\RenderPasses\WARDiffPathTracer\WarpedAreaReparam.slang
This is the current implementation:

```cpp
float computeHarmonicWeight(
    no_diff IntersectionAD isect,
    no_diff float3 origin,
    no_diff float3 auxDirection,
    no_diff float auxSampleY,
    no_diff float kappa,
    float3 direction
)
{
    float boundaryTerm = no_diff computeBoundaryTerm(isect.normalW, auxDirection);

    float sy = max(1.f - auxSampleY, 1e-6f);
    float invVMFDensity = 1.f / ((1.f - sy) * exp(-2.f * kappa) + sy);

    float wDenom = invVMFDensity - 1.f + boundaryTerm;
    float wDenomRcp = select(wDenom > 1e-4f, 1.f / wDenom, 0.f);
    float w = wDenomRcp * wDenomRcp * wDenomRcp * invVMFDensity;
    return w;
}
```

This function basically implements the computation of weight_i, a single line in Algorithm 2 in the paper.
It seems like the code doesn't match the formula given in the paper. Here is some derivation & explanation. (I will use 'w' for omega, unit direction and 'weight' for w in the paper for convenience)

- dot(w, w'). We take advantage of a fact that dot product doesn't change after we transform both vectors with same transformation. Thus, it equals the dot product in local space, where w_local is simply (0,0,1) and the sampled w'_local has z component cos(theta) = 1.f + log(exp(-2.f * kappa) * (1.f - sy) + sy) / kappa; See sampleVonMisesFisher() in Source\Falcor\Utils\Math\MathHelpers.slang for details.
- Following that, after some simple derivation, we have the exponential term in the denominator becomes (1.f - sy) * exp(-2.f * kappa) + sy, which should be "VMF density of w' ". 
- Thus, weight_i = 1 / (VMF_density - 1 + BoundaryTerm) / VMFDensity
- Further, I couldn't understand why there is a "1 / wDenom ^ 3". I didn't find anything in the calculation related to a cubic term.

And here is my modified implementation:

```cpp
float computeHarmonicWeight(
    no_diff IntersectionAD isect,
    no_diff float3 origin,
    no_diff float3 auxDirection,
    no_diff float auxSampleY,
    no_diff float kappa,
    float3 direction // not used in computation; allows autodiff to find grad w.r.t. this direction
)
{
    float boundaryTerm = no_diff computeBoundaryTerm(isect.normalW, auxDirection);

    float sy = max(1.f - auxSampleY, 1e-6f);
    // see WAS paper Algorithm 2, computation of weight_i
    /* float invVMFDensity = 1.f / ((1.f - sy) * exp(-2.f * kappa) + sy);

    float wDenom = invVMFDensity - 1.f + boundaryTerm;
    float wDenomRcp = select(wDenom > 1e-4f, 1.f / wDenom, 0.f);
    float w = wDenomRcp * wDenomRcp * wDenomRcp * invVMFDensity; */

    float VMFDensity = (1.f - sy) * exp(-2.f * kappa) + sy;
    float w = 1.f / (VMFDensity - 1.f + boundaryTerm) / VMFDensity;
    return w;
}
```

After the change, here is the bunny_ref test scene. (First is before change, second is after change.) I did see some very subtle difference. But admittedly, I am not an expert on Falcor, differentiable rendering, or WAS, so it's very possible I am wrong. But I do want to point things out in case there is something wrong. 

Thank you!

![BeforeChange](https://github.com/NVIDIAGameWorks/Falcor/assets/56232866/0bcc462a-f97d-4d06-a48c-797f3e494563)

![AfterChange](https://github.com/NVIDIAGameWorks/Falcor/assets/56232866/c48784cc-b3ad-40c4-9a71-3657bdcfe2c3)

Finally, here is the launch.json entry for this test scene for your convenience. 

```json
        {
            // Launch configuration for Mogwai (Warped Area Sampling Differentiable Rendering)
            "name": "Mogwai WAS",
            "type": "cppvsdbg",
            "request": "launch",
            "program": "${command:cmake.launchTargetPath}",
            "windows": {
                "program": "${command:cmake.launchTargetDirectory}/Mogwai.exe"
            },
            "args": [
                "--script=${workspaceFolder}/scripts/WARDiffPathTracer.py",
                "--scene=${workspaceFolder}/media/inv_rendering_scenes/bunny_ref.pyscene"
            ],
            "stopAtEntry": false,
            "cwd": "${command:cmake.launchTargetDirectory}",
            "environment": [
                {
                    "name": "FALCOR_DEVMODE",
                    "value": "1"
                }
            ],
            "visualizerFile": "${workspaceFolder}/Source/Falcor/Falcor.natvis"
        },
``` 