### PR TITLE
Fix a potential unbounded memory grow regarding `GraphicsState::mpGsoGraph`

### DIFF
--- a/Source/Falcor/Core/API/GraphicsStateObject.cpp
+++ b/Source/Falcor/Core/API/GraphicsStateObject.cpp
@@ -242,17 +242,9 @@ GraphicsStateObject::GraphicsStateObject(ref<Device> pDevice, const GraphicsStat
         spDefaultRasterizerState = RasterizerState::create(RasterizerState::Desc());
     }
 
-    // Initialize default objects
-    if (!mDesc.pBlendState)
-        mDesc.pBlendState = spDefaultBlendState;
-    if (!mDesc.pRasterizerState)
-        mDesc.pRasterizerState = spDefaultRasterizerState;
-    if (!mDesc.pDepthStencilState)
-        mDesc.pDepthStencilState = spDefaultDepthStencilState;
-
     gfx::GraphicsPipelineStateDesc gfxDesc = {};
     // Set blend state.
-    const auto& blendState = mDesc.pBlendState;
+    const auto& blendState = mDesc.pBlendState ? mDesc.pBlendState : spDefaultBlendState;
     FALCOR_ASSERT(blendState->getRtCount() <= gfx::kMaxRenderTargetCount);
     auto& targetBlendDescs = gfxDesc.blend.targets;
     {
@@ -285,7 +277,7 @@ GraphicsStateObject::GraphicsStateObject(ref<Device> pDevice, const GraphicsStat
 
     // Set depth stencil state.
     {
-        const auto& depthStencilState = mDesc.pDepthStencilState;
+        const auto& depthStencilState = mDesc.pDepthStencilState ? mDesc.pDepthStencilState : spDefaultDepthStencilState;
         getGFXStencilDesc(gfxDesc.depthStencil.backFace, depthStencilState->getStencilDesc(Falcor::DepthStencilState::Face::Back));
         getGFXStencilDesc(gfxDesc.depthStencil.frontFace, depthStencilState->getStencilDesc(Falcor::DepthStencilState::Face::Front));
         gfxDesc.depthStencil.depthFunc = getGFXComparisonFunc(depthStencilState->getDepthFunc());
@@ -299,7 +291,7 @@ GraphicsStateObject::GraphicsStateObject(ref<Device> pDevice, const GraphicsStat
 
     // Set raterizer state.
     {
-        const auto& rasterState = mDesc.pRasterizerState;
+        const auto& rasterState = mDesc.pRasterizerState ? mDesc.pRasterizerState : spDefaultRasterizerState;
         gfxDesc.rasterizer.antialiasedLineEnable = rasterState->isLineAntiAliasingEnabled();
         gfxDesc.rasterizer.cullMode = getGFXCullMode(rasterState->getCullMode());
         gfxDesc.rasterizer.depthBias = rasterState->getDepthBias();


### PR DESCRIPTION
I discovered that calling `pRenderContext->blit()` multiple times within the same frame might cause an abnormal continuous increase in CPU Time in the Profiler. 

After debugging, I found that an unbounded number of nodes are added to `GraphicsState::mpGsoGraph` in https://github.com/NVIDIAGameWorks/Falcor/blob/master/Source/Falcor/Core/State/GraphicsState.cpp.

I think the root cause of the issue is that the cached `GraphicsStateObject` in `GraphicsState::mpGsoGraph` are searched by comparing `GraphicsStateObjectDesc`: 
https://github.com/NVIDIAGameWorks/Falcor/blob/eb540f6748774680ce0039aaf3ac9279266ec521/Source/Falcor/Core/State/GraphicsState.cpp#L104
while `GraphicsStateObject::GraphicsStateObject(ref<Device> pDevice, const GraphicsStateObjectDesc& desc)` might modify `mDesc`:
https://github.com/NVIDIAGameWorks/Falcor/blob/eb540f6748774680ce0039aaf3ac9279266ec521/Source/Falcor/Core/API/GraphicsStateObject.cpp#L246
causing `pGso->getDesc()` to be different from the constructor parameter `desc`.

As a result, after executing https://github.com/NVIDIAGameWorks/Falcor/blob/eb540f6748774680ce0039aaf3ac9279266ec521/Source/Falcor/Core/State/GraphicsState.cpp#L115
https://github.com/NVIDIAGameWorks/Falcor/blob/eb540f6748774680ce0039aaf3ac9279266ec521/Source/Falcor/Core/State/GraphicsState.cpp#L106 can still return false, causing `mpGsoGraph->walk()` calls to unlimitedly add nodes to `mpGsoGraph`.

My solution is to avoid modifying `mDesc` in `GraphicsStateObject::GraphicsStateObject()`, which can fix the issue.