### PR TITLE
Update outdated references to RenderGraphs (Mogwai/Data/) in tutorials

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ The `Source/Falcor` folder contains the Falcor core framework. It is built as a 
 The `Source/Samples` folder contains the Falcor sample applications. Each application is using Falcor directly and demonstrates how to use some of the fundamental features and abstractions Falcor provides.
 
 ### Mogwai
-The `Source/Mogwai` folder contains the Mogwai application. It's the main application for using render graphs and provides some useful utilities. Some sample render graphs are located under its project folder: `Source/Mogwai/Data/`.
+The `Source/Mogwai` folder contains the Mogwai application. It's the main application for using render graphs and provides some useful utilities. Some sample render graphs are located under its project folder: `scripts/`.
 
 ### RenderPasses
 The `Source/RenderPasses` folder contains a number of components (shared libraries) that are used as the building blocks for creating render graphs. All render pass libraries are automatically built as dependencies of the `Mogwai` application.
@@ -29,7 +29,7 @@ The recommended workflow when prototyping or implementing rendering techniques i
 1. Build Falcor
 2. Run `Mogwai`
 3. Press `Ctrl+O`, or from the top menu bar, select `File` -> `Load Script`
-4. Select a Render Graph (.py file) in `Source/Mogwai/Data/`. Such as `ForwardRenderer.py`.
+4. Select a Render Graph (.py file) in `scripts/`. Such as `MinimalPathTracer.py`.
 5. Press `Ctrl+Shift+O`, or from the top menu bar, select `File` -> `Load Scene`.
 6. Select a scene or model, such as `media/Arcade/Arcade.pyscene`
 

--- a/docs/tutorials/01-mogwai-usage.md
+++ b/docs/tutorials/01-mogwai-usage.md
@@ -65,7 +65,7 @@ With Mogwai up and running, we'll proceed to loading something. You can load two
 ### Loading a Script (.py)
 Open the load script dialog by either going to `File -> Load Script` or hitting `Ctrl + O`. Navigate to the location of the script you wish to run and select it to load and run it. Alternatively, dragging-and-dropping a script into Mogwai will also work. Note that scripts intended for use with Mogwai must be written in Python. Full scripting documentation can be found [here](../usage/scripting.md).
 
-Here, we'll load the Forward Renderer, located at `Source/Mogwai/Data/ForwardRenderer.py`.
+Here, we'll load the Minimal Path Tracer, located at `scripts/MinimalPathTracer.py`.
 
 ### Loading a Scene
 Mogwai loads the scene specified by the script, if any. If the script did not load a scene or you want to load a different scene, open the load scene dialog by either going to `File` -> `Load Scene` or hitting `Ctrl + Shift + O`. Navigate to the location of the scene file you wish to load and select it. Alternatively, you can also drag-and-drop scene files into Mogwai.

--- a/docs/usage/path-tracer.md
+++ b/docs/usage/path-tracer.md
@@ -8,7 +8,7 @@
 
 1. Build Falcor
 2. Launch Mogwai
-3. The sample Path Tracer render graph file is located at `Source/Mogwai/Data/PathTracer.py`. There is also an alternative real-time denoised Path Tracer render graph at `Source/Mogwai/Data/PathTracerNRD.py`. You can load any one of them using any of the following methods:
+3. The sample Path Tracer render graph file is located at `scripts/PathTracer.py`. There is also an alternative real-time denoised Path Tracer render graph at `scripts/PathTracerNRD.py`. You can load any one of them using any of the following methods:
     - Press `Ctrl + O` (or click `Load Script` in the top menu bar), then navigate to `PathTracer.py` or `PathTracerNRD.py`.
     - Drag and drop  `PathTracer.py` or `PathTracerNRD.py` into the application window.
     - Load script at startup using the Mogwai `--script` command line option.


### PR DESCRIPTION
The current documentation is a bit outdated regarding getting the scripts for Mogwai. This PR will update all of these references which used to point to `Mogwai/Data/` (which no longer exists) to use the `scripts/` folder instead.