### PR TITLE
Fixed filename comparison on Mogwai's side

### DIFF
--- a/Source/Falcor/Core/Platform/Windows/Windows.cpp
+++ b/Source/Falcor/Core/Platform/Windows/Windows.cpp
@@ -796,7 +796,7 @@ static void checkFileModifiedStatus(const std::filesystem::path& path, const std
         while (offset < buffer.size())
         {
             _FILE_NOTIFY_INFORMATION* pNotifyInformation = reinterpret_cast<_FILE_NOTIFY_INFORMATION*>(buffer.data());
-            std::wstring currentFilename(pNotifyInformation->FileName, pNotifyInformation->FileName + pNotifyInformation->FileNameLength);
+            std::wstring currentFilename(pNotifyInformation->FileName, pNotifyInformation->FileName + pNotifyInformation->FileNameLength / sizeof(wchar_t));
 
             if (currentFilename == filename && pNotifyInformation->Action == FILE_ACTION_MODIFIED)
             {


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-file_notify_information, FileNameLength is the size in bytes, and since we have wide string, actual amount of symbols will be FileNameLength / sizeof(wchar_t)

Without this change I haven't been able to see changes that I do in RenderGraphEditor in Mogwai, when I open RenderGraphEditor through Mogwai with Edit button. 