### PR TITLE
Adjust camera aspect ratio on scene load

### DIFF
--- a/Source/Falcor/Core/Testbed.cpp
+++ b/Source/Falcor/Core/Testbed.cpp
@@ -158,6 +158,10 @@ void Testbed::loadScene(const std::filesystem::path& path, SceneBuilder::Flags b
 {
     mpScene = SceneBuilder(mpDevice, path, Settings(), buildFlags).getScene();
 
+    // Adjust the camera aspect ratio.
+    if (mpScene && mpTargetFBO)
+        mpScene->setCameraAspectRatio(mpTargetFBO->getWidth() / float(mpTargetFBO->getHeight()));
+
     if (mpRenderGraph)
         mpRenderGraph->setScene(mpScene);
 }
@@ -165,6 +169,10 @@ void Testbed::loadScene(const std::filesystem::path& path, SceneBuilder::Flags b
 void Testbed::loadSceneFromString(const std::string& scene, const std::string extension, SceneBuilder::Flags buildFlags)
 {
     mpScene = SceneBuilder(mpDevice, scene.data(), scene.length(), extension, Settings(), buildFlags).getScene();
+
+    // Adjust the camera aspect ratio.
+    if (mpScene && mpTargetFBO)
+        mpScene->setCameraAspectRatio(mpTargetFBO->getWidth() / float(mpTargetFBO->getHeight()));
 
     if (mpRenderGraph)
         mpRenderGraph->setScene(mpScene);


### PR DESCRIPTION
Added camera aspect ratio adjustment when loading scenes in testbed. Before, this was not done, leading to wrong scaling when adjusting the resolution of the testbed.

fixes #481 